### PR TITLE
Fix: Grafana example working on Arm with version 6.7.1

### DIFF
--- a/grafana/docker-compose.yml
+++ b/grafana/docker-compose.yml
@@ -11,7 +11,7 @@ services:
             - '3000:3000'
         links:
             - influxdb
-        image: grafana/grafana
+        image: grafana/grafana:6.7.1
 
     influxdb:
         container_name: influxdb


### PR DESCRIPTION
Grafana does not work on Arm architecture with the tag "**latest**". Adding the latest stable version tag "**6.7.1**" it is also working on Arm.