### PR TITLE
Fix app-ids to display the tic-tac-toe app

### DIFF
--- a/multi-display/single-drm-interface/weston.ini
+++ b/multi-display/single-drm-interface/weston.ini
@@ -17,4 +17,4 @@ app-ids=org.qt-project.animation
 
 [output]
 name=LVDS-1
-app-ids=org.qt-project.animation
+app-ids=capp


### PR DESCRIPTION
For one of the outputs it must be `org.qt-project.animation` (for the Qt app) and for the other, it must be `capp` (for the tic-tac-toe app).