### PR TITLE
demostration: add "253:*" cgroup rules docker-compose.imx8.yml

### DIFF
--- a/debian-container/demonstration/docker-compose.imx8.yml
+++ b/debian-container/demonstration/docker-compose.imx8.yml
@@ -33,3 +33,5 @@ services:
       - 'c 226:* rmw'
       # ... for /dev/galcore device
       - 'c 199:0 rmw'
+      # ... for /dev/dma_heap device
+      - 'c 253:* rmw'


### PR DESCRIPTION
This is needed for Apalis iMX8 and Colibri iMX8X SoMs to make use of g2d library for offloading 2D computation to HW.

Related-to: TCCP-830