### PR TITLE
Add ISP usage sample with demo for Framos FSM:GO cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Folders:
   collectd-influxdb-grafana setup
 - **gstreamer**
   in a docker container on Torizon
+- **isp**
+  resources to use Framos FSM:GO cameras on Torizon using containers
 - **multi-display**
   sample showing how to use multiple displays
 - **nodejs**

--- a/isp/imx8mp/framos/README.md
+++ b/isp/imx8mp/framos/README.md
@@ -1,0 +1,18 @@
+# About this sample
+
+This sample provides the required resources to use Framos FSM:GO Cameras with supported modules on Torizon.
+It includes the needed files to run the isp-imx application in a container and auxiliary scripts for building a custom Torizon OS image including the required configurations with TorizonCore Builder tool.
+
+This sample is compatible with the following hardware:
+
+ - 0070 - Verdin iMX8M Plus Quad 8GB WB IT
+ - 0058 - Verdin iMX8M Plus Quad 4GB WB IT
+ - 0063 - Verdin iMX8M Plus Quad 4GB IT
+
+Currently, this demo should be used with the following TorizonOS versions:
+
+- TorizonOS 6  (Starting from 6.8.0)
+- TorizonOS 7  (Starting from 7.0.0)
+
+Please refer to [How to run Framos FSM:GO Cameras on Torizon](https://developer.toradex.com/torizon/application-development/use-cases/multimedia/first-steps-with-fsm-go-csi-optical-sensor-modules-torizon/) to learn more on how to use this sample and the Cameras.
+

--- a/isp/imx8mp/framos/Torizon6/docker-compose.yaml
+++ b/isp/imx8mp/framos/Torizon6/docker-compose.yaml
@@ -1,0 +1,65 @@
+version: '3'
+
+services:
+  weston:
+    image: torizon/weston-vivante:3
+    container_name: weston
+    command:
+      - --tty=/dev/tty7
+    environment:
+      - ACCEPT_FSL_EULA=1
+    network_mode: host
+    cap_add:
+      - CAP_SYS_TTY_CONFIG
+    volumes:
+      - /dev/:/dev/
+      - /tmp:/tmp
+      - /run/udev/:/run/udev/
+    device_cgroup_rules:
+      - 'c 4:* rmw'
+      - 'c 13:* rmw'
+      - 'c 199:* rmw'
+      - 'c 226:* rmw'
+
+  isp-imx:
+    image: <your-dockerhub-username>/torizon6-isp-imx
+    container_name: isp-imx
+    working_dir: /build-isp-imx/opt/imx8-isp/bin/
+    command: ["./start_isp.sh", "sleep 3"]
+    environment:
+      - ACCEPT_FSL_EULA=1
+    cap_add:
+      - CAP_SYS_TTY_CONFIG
+    volumes:
+      - /tmp:/tmp
+      - /var/run/dbus:/var/run/dbus
+      - /dev:/dev
+      - /sys:/sys
+      - /lib/modules:/lib/modules
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+    tty: true
+    depends_on:
+      - weston
+    privileged: true
+    pull_policy: always
+
+  gstreamer:
+    image: <your-dockerhub-username>/gst_example
+    container_name: gstreamer
+    entrypoint: ["gst-launch-1.0", "-v", "v4l2src", "device=/dev/video2", "!", "video/x-raw", "!", "videoconvert", "!", "waylandsink"]
+    volumes:
+      - /var/rootdirs/media:/media:z
+      - /tmp:/tmp
+      - /var/run/dbus:/var/run/dbus
+      - /dev:/dev
+    device_cgroup_rules:
+      - 'c 199:* rmw'
+      - 'c 226:* rmw'
+      - 'c 81:* rmw'
+    depends_on:
+      isp-imx:
+        condition: service_healthy

--- a/isp/imx8mp/framos/Torizon6/isp-imx/Dockerfile
+++ b/isp/imx8mp/framos/Torizon6/isp-imx/Dockerfile
@@ -1,0 +1,78 @@
+ARG BASE_NAME=wayland-base-vivante
+ARG IMAGE_ARCH=linux/arm64
+ARG IMAGE_TAG=3
+ARG DOCKER_REGISTRY=torizon
+
+FROM --platform=$IMAGE_ARCH $DOCKER_REGISTRY/$BASE_NAME:$IMAGE_TAG AS framos-build
+
+ARG ISP_IMX_VERSION="4.2.2.20.0"
+ARG ACCEPT_FSL_EULA=1
+ARG ISP_IMX_URL="https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/isp-imx-$ISP_IMX_VERSION.bin"
+
+## Install build dependencies
+
+RUN apt-get -y update && apt-get install -y \
+    cmake build-essential gcc g++ git wget unzip patchelf \
+    autoconf automake libtool curl gfortran libboost-all-dev \
+    libwayland-dev libdrm-dev libg2d-dpu-dev libg2d-dpu \
+    libtinyxml2-dev linux-imx-headers-dev patch kmod
+
+# Create Symlinks for libraries
+
+RUN ln -s /usr/lib/aarch64-linux-gnu/libtinyxml2.so /usr/lib/libtinyxml2.so
+RUN ln -s /usr/include/libdrm /usr/include/drm
+
+WORKDIR downloads
+
+# download and extract isp-imx from NXP site
+
+RUN wget -O isp-imx-$ISP_IMX_VERSION.bin $ISP_IMX_URL
+RUN chmod +x isp-imx-$ISP_IMX_VERSION.bin
+RUN ./isp-imx-$ISP_IMX_VERSION.bin --auto-accept --force
+
+# apply patches for framos cameras
+
+COPY patches/ /downloads/isp-imx-$ISP_IMX_VERSION/patches
+
+WORKDIR /downloads/isp-imx-$ISP_IMX_VERSION/patches
+RUN ./patch.sh
+
+# build isp-imx
+
+WORKDIR /downloads/isp-imx-$ISP_IMX_VERSION/
+RUN ./build-all-isp.sh Release v4l2
+
+# apply patch to use bash instead of sh in some isp scripts
+WORKDIR /downloads/isp-imx-$ISP_IMX_VERSION/patches
+RUN ./sed-bash.sh
+
+FROM --platform=$IMAGE_ARCH $DOCKER_REGISTRY/$BASE_NAME:$IMAGE_TAG AS framos-base
+
+ARG ISP_IMX_VERSION=4.2.2.20.0
+ARG ACCEPT_FSL_EULA=1
+ARG SRC_DIR=/downloads/isp-imx-${ISP_IMX_VERSION}
+ARG BUILD_DIR=${SRC_DIR}/build_output_release_v4l2
+ARG INSTALL_DIR=/build-isp-imx/opt/imx8-isp
+
+WORKDIR /build-isp-imx/opt/imx8-isp/
+RUN mkdir -p /build-isp-imx/opt/imx8-isp/bin
+RUN mkdir -p /build-isp-imx/opt/imx8-isp/bin/dewarp_config
+RUN mkdir -p /build-isp-imx/opt/imx8-isp/lib
+RUN mkdir -p /build-isp-imx/opt/imx8-isp/include
+
+RUN apt-get -y update && apt-get install -y tree kmod libtinyxml2-dev procps
+
+## Copy compiled binaries, libraries, and other files
+COPY --from=framos-build /downloads/isp-imx-$ISP_IMX_VERSION/build_output_release_v4l2/opt/imx8-isp/bin/video_test /build-isp-imx/opt/imx8-isp/bin
+COPY --from=framos-build /downloads/isp-imx-$ISP_IMX_VERSION/build_output_release_v4l2/opt/imx8-isp/bin/IMX*.xml /build-isp-imx/opt/imx8-isp/bin/
+COPY --from=framos-build /downloads/isp-imx-$ISP_IMX_VERSION/build_output_release_v4l2/opt/imx8-isp/bin/imx*.drv /build-isp-imx/opt/imx8-isp/bin/
+COPY --from=framos-build $SRC_DIR/dewarp/dewarp_config/ $INSTALL_DIR/bin/dewarp_config
+COPY --from=framos-build $BUILD_DIR/opt/imx8-isp/bin/isp_media_server $INSTALL_DIR/bin
+COPY --from=framos-build $BUILD_DIR/opt/imx8-isp/bin/vvext $INSTALL_DIR/bin
+COPY --from=framos-build $BUILD_DIR/usr/lib/ $INSTALL_DIR/lib/
+RUN cp $INSTALL_DIR/lib/lib*.so* /usr/lib/
+
+# Copy any extra scripts from source
+COPY --from=framos-build $BUILD_DIR/opt/imx8-isp/bin/start_isp.sh $INSTALL_DIR/bin
+COPY --from=framos-build $BUILD_DIR/opt/imx8-isp/bin/run.sh $INSTALL_DIR/bin
+RUN chmod +x $INSTALL_DIR/bin/run.sh $INSTALL_DIR/bin/start_isp.sh

--- a/isp/imx8mp/framos/Torizon6/isp-imx/patches/0001-isp-imx-start_isp-don-t-report-error-if-no-camera-is.patch
+++ b/isp/imx8mp/framos/Torizon6/isp-imx/patches/0001-isp-imx-start_isp-don-t-report-error-if-no-camera-is.patch
@@ -1,0 +1,32 @@
+From 3443f18dc9ab8950071d6299c7a5da86055f3318 Mon Sep 17 00:00:00 2001
+From: Max Krummenacher <max.krummenacher@toradex.com>
+Date: Thu, 19 Jan 2023 15:51:24 +0000
+Subject: [PATCH] isp-imx: start_isp: don't report error if no camera is
+ configured
+
+The script currently returns '6' when no known camera is configured
+in the device tree. The end result is that the systemd imx8-isp.service
+goes to the failed state.
+Return '0' in that case as obviously the device tree doesn't have a
+camera configured and the service is not needed.
+
+Related-to: ELB-5002
+Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>
+---
+ imx/start_isp.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/imx/start_isp.sh b/imx/start_isp.sh
+index 95cbc19..d603f8f 100755
+--- a/imx/start_isp.sh
++++ b/imx/start_isp.sh
+@@ -74,5 +74,5 @@ elif [ $NR_DEVICE_TREE_OS08A20 -eq 2 ]; then
+ else
+ 	# no device tree found exit with code no device or address
+ 	echo "No device tree found for Basler camera or os08a20, check dtb file!" >&2
+-	exit 6
++	exit 0
+ fi
+-- 
+2.35.3
+

--- a/isp/imx8mp/framos/Torizon6/isp-imx/patches/0002-Add-support-for-imx6xx-sensors.patch
+++ b/isp/imx8mp/framos/Torizon6/isp-imx/patches/0002-Add-support-for-imx6xx-sensors.patch
@@ -1,0 +1,16501 @@
+From 0686a0a39c4980816d44fbf2c1d27b6ddee1be43 Mon Sep 17 00:00:00 2001
+From: Marcio Albano <marcio.ferreira@toradex.com>
+Date: Fri, 20 Sep 2024 18:08:06 -0300
+Subject: [PATCH] Add support for imx6xx sensors
+
+---
+ build-all-isp.sh                              |    6 +
+ .../sensor_dwe_IMX662_Basic_1280x720.json     |   54 +
+ .../sensor_dwe_IMX662_Basic_1920x1080.json    |   54 +
+ .../sensor_dwe_IMX662_Basic_640x480.json      |   54 +
+ .../sensor_dwe_IMX662_Basic_960x540.json      |   54 +
+ .../sensor_dwe_IMX676_Basic_1760x1070.json    |   54 +
+ .../sensor_dwe_IMX676_Basic_1776x1778.json    |   54 +
+ .../sensor_dwe_IMX676_Basic_3536x2140.json    |   54 +
+ .../sensor_dwe_IMX676_Basic_3536x3072.json    |   54 +
+ .../sensor_dwe_IMX678_Basic_1920x1080.json    |   54 +
+ .../sensor_dwe_IMX678_Basic_3840x2160.json    |   54 +
+ imx/run.sh                                    |  102 ++
+ imx/start_isp.sh                              |   60 +-
+ units/isi/CMakeLists.txt                      |    4 +
+ units/isi/drv/imx662/CMakeLists.txt           |  122 ++
+ units/isi/drv/imx662/Sensor0_Entry.cfg        |   15 +
+ units/isi/drv/imx662/Sensor1_Entry.cfg        |   15 +
+ units/isi/drv/imx662/calib/CMakeLists.txt     |   44 +
+ .../calib/IMX662/IMX662_Basic_1280x720.xml    | 1103 ++++++++++++++
+ .../calib/IMX662/IMX662_Basic_1920x1080.xml   | 1103 ++++++++++++++
+ .../calib/IMX662/IMX662_Basic_640x480.xml     | 1103 ++++++++++++++
+ .../calib/IMX662/IMX662_Basic_960x540.xml     | 1103 ++++++++++++++
+ units/isi/drv/imx662/source/IMX662.c          | 1268 +++++++++++++++++
+ units/isi/drv/imx676/CMakeLists.txt           |  122 ++
+ units/isi/drv/imx676/Sensor0_Entry.cfg        |   16 +
+ units/isi/drv/imx676/Sensor1_Entry.cfg        |   16 +
+ units/isi/drv/imx676/calib/CMakeLists.txt     |   44 +
+ .../calib/IMX676/IMX676_Basic_1760x1070.xml   | 1103 ++++++++++++++
+ .../calib/IMX676/IMX676_Basic_1776x1778.xml   | 1103 ++++++++++++++
+ .../calib/IMX676/IMX676_Basic_3536x2140.xml   | 1103 ++++++++++++++
+ .../calib/IMX676/IMX676_Basic_3536x3072.xml   | 1103 ++++++++++++++
+ units/isi/drv/imx676/source/IMX676.c          | 1268 +++++++++++++++++
+ units/isi/drv/imx678/CMakeLists.txt           |  122 ++
+ units/isi/drv/imx678/Sensor0_Entry.cfg        |   10 +
+ units/isi/drv/imx678/Sensor1_Entry.cfg        |   10 +
+ units/isi/drv/imx678/calib/CMakeLists.txt     |   44 +
+ .../calib/IMX678/IMX678_Basic_1920x1080.xml   | 1103 ++++++++++++++
+ .../calib/IMX678/IMX678_Basic_3840x2160.xml   | 1103 ++++++++++++++
+ units/isi/drv/imx678/source/IMX678.c          | 1268 +++++++++++++++++
+ 39 files changed, 16125 insertions(+), 1 deletion(-)
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json
+ create mode 100755 units/isi/drv/imx662/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx662/Sensor0_Entry.cfg
+ create mode 100644 units/isi/drv/imx662/Sensor1_Entry.cfg
+ create mode 100644 units/isi/drv/imx662/calib/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1280x720.xml
+ create mode 100644 units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1920x1080.xml
+ create mode 100644 units/isi/drv/imx662/calib/IMX662/IMX662_Basic_640x480.xml
+ create mode 100644 units/isi/drv/imx662/calib/IMX662/IMX662_Basic_960x540.xml
+ create mode 100644 units/isi/drv/imx662/source/IMX662.c
+ create mode 100755 units/isi/drv/imx676/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx676/Sensor0_Entry.cfg
+ create mode 100644 units/isi/drv/imx676/Sensor1_Entry.cfg
+ create mode 100644 units/isi/drv/imx676/calib/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1760x1070.xml
+ create mode 100644 units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1776x1778.xml
+ create mode 100644 units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x2140.xml
+ create mode 100644 units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x3072.xml
+ create mode 100644 units/isi/drv/imx676/source/IMX676.c
+ create mode 100755 units/isi/drv/imx678/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx678/Sensor0_Entry.cfg
+ create mode 100644 units/isi/drv/imx678/Sensor1_Entry.cfg
+ create mode 100644 units/isi/drv/imx678/calib/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx678/calib/IMX678/IMX678_Basic_1920x1080.xml
+ create mode 100644 units/isi/drv/imx678/calib/IMX678/IMX678_Basic_3840x2160.xml
+ create mode 100644 units/isi/drv/imx678/source/IMX678.c
+
+diff --git a/build-all-isp.sh b/build-all-isp.sh
+index 5dcd8f5..6cdd916 100755
+--- a/build-all-isp.sh
++++ b/build-all-isp.sh
+@@ -118,6 +118,12 @@ cp -a appshell/build/generated/${BUILD_DIR}/lib/*.so* ${ISP_LIB_DIR}
+ #cp -a appshell/build/generated/${BUILD_TYPE}/bin/ov2775* ${ISP_BIN_DIR}
+ cp -a appshell/build/generated/${BUILD_TYPE}/bin/OS08a20* ${ISP_BIN_DIR}
+ cp -a appshell/build/generated/${BUILD_TYPE}/bin/os08a20* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/IMX662* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/imx662* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/IMX676* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/imx676* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/IMX678* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/imx678* ${ISP_BIN_DIR}
+ cp -a appshell/build/generated/${BUILD_TYPE}/bin/isp_media_server ${ISP_BIN_DIR}
+ cp -a appshell/build/generated/${BUILD_TYPE}/bin/*_test ${ISP_BIN_DIR}
+ cp -a appshell/build/generated/${BUILD_DIR}/bin/*.cfg ${ISP_BIN_DIR}/
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json
+new file mode 100644
+index 0000000..a8885c0
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1280,
++                "height": 720
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 360,
++                "vertical_line_up": 640,
++                "vertical_line_down": 640
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                640.0,
++                0.0,
++                1000.0,
++                360.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}--- dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json
+new file mode 100644
+index 0000000..4f878aa
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1920,
++                "height": 1080
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 540,
++                "vertical_line_up": 960,
++                "vertical_line_down": 960
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                960.0,
++                0.0,
++                1000.0,
++                540.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}--- dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json
+new file mode 100644
+index 0000000..7c4efff
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 640,
++                "height": 480
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 240,
++                "vertical_line_up": 320,
++                "vertical_line_down": 320
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                320.0,
++                0.0,
++                1000.0,
++                240.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}--- dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json
+new file mode 100644
+index 0000000..37bfed5
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 960,
++                "height": 540
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 270,
++                "vertical_line_up": 480,
++                "vertical_line_down": 480
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                480.0,
++                0.0,
++                1000.0,
++                270.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}--- imx/run.sh
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json
+new file mode 100644
+index 0000000..9c608e3
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1760,
++                "height": 1070
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 535,
++                "vertical_line_up": 880,
++                "vertical_line_down": 880
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                320.0,
++                0.0,
++                1000.0,
++                240.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json
+new file mode 100644
+index 0000000..597e60b
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1776,
++                "height": 1778
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 889,
++                "vertical_line_up": 888,
++                "vertical_line_down": 888
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                888.0,
++                0.0,
++                1000.0,
++                889.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json
+new file mode 100644
+index 0000000..c3261cd
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 3536,
++                "height": 2140
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 1070,
++                "vertical_line_up": 1768,
++                "vertical_line_down": 1768
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                1768.0,
++                0.0,
++                1000.0,
++                1070.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json
+new file mode 100644
+index 0000000..a862edb
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 3536,
++                "height": 3072
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 1536,
++                "vertical_line_up": 1768,
++                "vertical_line_down": 1768
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                1768.0,
++                0.0,
++                1000.0,
++                1536.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json b/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json
+new file mode 100644
+index 0000000..e7351ce
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1920,
++                "height": 1080
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 540,
++                "vertical_line_up": 960,
++                "vertical_line_down": 960
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                960.0,
++                0.0,
++                1000.0,
++                540.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json b/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json
+new file mode 100644
+index 0000000..ad9c7ae
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 3840,
++                "height": 2160
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 1080,
++                "vertical_line_up": 1920,
++                "vertical_line_down": 1920
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                1920.0,
++                0.0,
++                1000.0,
++                1080.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/imx/run.sh b/imx/run.sh
+index 4ed3669..bf0dfd7 100755
+--- a/imx/run.sh
++++ b/imx/run.sh
+@@ -3,6 +3,7 @@
+ # Start the isp_media_server in the configuration from user
+ # (c) NXP 2020-2022
+ # (c) Basler 2020
++# (c) Framos 2024
+ #
+ 
+ RUN_SCRIPT=`realpath -s $0`
+@@ -87,6 +88,43 @@ write_default_mode_files () {
+ 	echo "[mode.3]" >> DAA3840_MODES.txt
+ 	echo "xml = \"DAA3840_30MC_1080P-hdr.xml\"" >> DAA3840_MODES.txt
+ 	echo "dwe = \"dewarp_config/daA3840_30mc_1080P.json\"" >> DAA3840_MODES.txt
++
++	# IMX662 modes file
++	echo -n "" > IMX662_MODES.txt
++	echo "[mode.0]" >> IMX662_MODES.txt
++	echo "xml = \"IMX662_Basic_1920x1080.xml\"" >> IMX662_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json\"" >> IMX662_MODES.txt
++	echo "[mode.1]" >> IMX662_MODES.txt
++	echo "xml = \"IMX662_Basic_1280x720.xml\"" >> IMX662_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json\"" >> IMX662_MODES.txt
++	echo "[mode.2]" >> IMX662_MODES.txt
++	echo "xml = \"IMX662_Basic_960x540.xml\"" >> IMX662_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX662_Basic_960x540.json\"" >> IMX662_MODES.txt
++	echo "[mode.3]" >> IMX662_MODES.txt
++	echo "xml = \"IMX662_Basic_640x480.xml\"" >> IMX662_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX662_Basic_640x480.json\"" >> IMX662_MODES.txt
++	# IMX676 modes file
++	echo -n "" > IMX676_MODES.txt
++	echo "[mode.0]" >> IMX676_MODES.txt
++	echo "xml = \"IMX676_Basic_3536x3072.xml\"" >> IMX676_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json\"" >> IMX676_MODES.txt
++	echo "[mode.1]" >> IMX676_MODES.txt
++	echo "xml = \"IMX676_Basic_3536x2140.xml\"" >> IMX676_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json\"" >> IMX676_MODES.txt
++	echo "[mode.2]" >> IMX676_MODES.txt
++	echo "xml = \"IMX676_Basic_1776x1778.xml\"" >> IMX676_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json\"" >> IMX676_MODES.txt
++	echo "[mode.3]" >> IMX676_MODES.txt
++	echo "xml = \"IMX676_Basic_1760x1070.xml\"" >> IMX676_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json\"" >> IMX676_MODES.txt
++	# IMX678 modes file
++	echo -n "" > IMX678_MODES.txt
++	echo "[mode.0]" >> IMX678_MODES.txt
++	echo "xml = \"IMX678_Basic_3840x2160.xml\"" >> IMX678_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json\"" >> IMX678_MODES.txt
++	echo "[mode.1]" >> IMX678_MODES.txt
++	echo "xml = \"IMX678_Basic_1920x1080.xml\"" >> IMX678_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json\"" >> IMX678_MODES.txt
+ }
+ 
+ # write the sensonr config file
+@@ -308,6 +346,70 @@ case "$ISP_CONFIG" in
+                          write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
+                          write_sensor_cfg_file "Sensor1_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
+                          ;;
++		imx662 )
++			MODULES_TO_REMOVE=("imx662" "${MODULES[@]}")
++			MODULES=("imx662" "${MODULES[@]}")
++			RUN_OPTION="CAMERA0"
++			CAM_NAME="imx662"
++			DRV_FILE="imx662.drv"
++			MODE_FILE="IMX662_MODES.txt"
++			MODE="0"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++		dual_imx662 )
++			MODULES_TO_REMOVE=("imx662" "${MODULES[@]}")
++			MODULES=("imx662" "${MODULES[@]}")
++			RUN_OPTION="DUAL_CAMERA"
++			CAM_NAME="imx662"
++			DRV_FILE="imx662.drv"
++			MODE_FILE="IMX662_MODES.txt"
++			MODE="0"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			write_sensor_cfg_file "Sensor1_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++		imx676_4k )
++			MODULES_TO_REMOVE=("imx676" "${MODULES[@]}")
++			MODULES=("imx676" "${MODULES[@]}")
++			RUN_OPTION="CAMERA0"
++			CAM_NAME="imx676"
++			DRV_FILE="imx676.drv"
++			MODE_FILE="IMX676_MODES.txt"
++			MODE="0"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++
++		dual_imx676_4k )
++			MODULES_TO_REMOVE=("imx676" "${MODULES[@]}")
++			MODULES=("imx676" "${MODULES[@]}")
++			RUN_OPTION="DUAL_CAMERA"
++			CAM_NAME="imx676"
++			DRV_FILE="imx676.drv"
++			MODE_FILE="IMX676_MODES.txt"
++			MODE="3"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			write_sensor_cfg_file "Sensor1_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++		imx678_4k )
++			MODULES_TO_REMOVE=("imx678" "${MODULES[@]}")
++			MODULES=("imx678" "${MODULES[@]}")
++			RUN_OPTION="CAMERA0"
++			CAM_NAME="imx678"
++			DRV_FILE="imx678.drv"
++			MODE_FILE="IMX678_MODES.txt"
++			MODE="0"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++		dual_imx678_4k )
++			MODULES_TO_REMOVE=("imx678" "${MODULES[@]}")
++			MODULES=("imx678" "${MODULES[@]}")
++			RUN_OPTION="DUAL_CAMERA"
++			CAM_NAME="imx678"
++			DRV_FILE="imx678.drv"
++			MODE_FILE="IMX678_MODES.txt"
++			MODE="1"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			write_sensor_cfg_file "Sensor1_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
+ 		 *)
+ 			echo "ISP configuration \"$ISP_CONFIG\" unsupported."
+ 			echo -e "$USAGE" >&2
+diff --git a/imx/start_isp.sh b/imx/start_isp.sh
+index 22e7783..311924f 100755
+--- a/imx/start_isp.sh
++++ b/imx/start_isp.sh
+@@ -1,9 +1,11 @@
+ #!/bin/sh
+ #
+ # Start the isp_media_server in the configuration for Basler daA3840-30mc
++# Also start the isp_media_server in the configuration for Framos IMX662
+ #
+ # (c) Basler 2020
+ # (c) NXP 2020-2022
++# (c) Framos 2024
+ #
+ 
+ RUNTIME_DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+@@ -11,6 +13,11 @@ NR_DEVICE_TREE_BASLER=$(grep basler-camera-vvcam `find /sys/firmware/devicetree/
+ NR_DEVICE_TREE_OV5640=$(grep ov5640 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
+ NR_DEVICE_TREE_OS08A20=$(grep os08a20 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
+ 
++NR_DEVICE_TREE_IMX662=$(grep imx662 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
++NR_DEVICE_TREE_IMX676=$(grep imx676 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
++NR_DEVICE_TREE_IMX678=$(grep imx678 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
++
++
+ 
+ # check if the basler device has been enabled in the device tree
+ if [ $NR_DEVICE_TREE_BASLER -eq 1 ]; then
+@@ -69,8 +76,59 @@ elif [ $NR_DEVICE_TREE_OS08A20 -eq 2 ]; then
+ 	# Available configurations: dual_Os08a20_1080p60, dual_Os08a20_1080p30hdr
+ 	exec ./run.sh -c dual_os08a20_1080p60 -lm
+ 
++# check for imx662 devices
++elif [ $NR_DEVICE_TREE_IMX662 -eq 2 ]; then
++
++	echo "Starting isp_media_server for Dual IMX662"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c dual_imx662 -lm
++
++elif [ $NR_DEVICE_TREE_IMX662 -eq 1 ]; then
++
++	echo "Starting isp_media_server for IMX662"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c imx662 -lm
++
++# check for imx676 devices
++elif [ $NR_DEVICE_TREE_IMX676 -eq 2 ]; then
++
++	echo "Starting isp_media_server for Dual IMX676"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c dual_imx676_4k -lm
++	
++elif [ $NR_DEVICE_TREE_IMX676 -eq 1 ]; then
++
++	echo "Starting isp_media_server for IMX676"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c imx676_4k -lm
++
++# check for imx678 devices
++elif [ $NR_DEVICE_TREE_IMX678 -eq 2 ]; then
++
++	echo "Starting isp_media_server for Dual IMX678"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c dual_imx678_4k -lm
++	
++elif [ $NR_DEVICE_TREE_IMX678 -eq 1 ]; then
++
++	echo "Starting isp_media_server for IMX678"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c imx678_4k -lm
++
+ else
+ 	# no device tree found exit with code no device or address
+-	echo "No device tree found for Basler camera or os08a20, check dtb file!" >&2
++	echo "No device tree found for image sensors, check dtb file!" >&2
+ 	exit 0
+ fi
+diff --git a/units/isi/CMakeLists.txt b/units/isi/CMakeLists.txt
+index 0775d24..e0177ed 100755
+--- a/units/isi/CMakeLists.txt
++++ b/units/isi/CMakeLists.txt
+@@ -78,4 +78,8 @@ include(${UNITS_TOP_DIRECTORY}/targets.cmake)
+ 
+ # add sensor driver modules here
+ add_subdirectory( drv/OS08a20 )
++add_subdirectory( drv/imx662 )
++add_subdirectory( drv/imx676 )
++add_subdirectory( drv/imx678 )
++
+ 
+diff --git a/units/isi/drv/imx662/CMakeLists.txt b/units/isi/drv/imx662/CMakeLists.txt
+new file mode 100755
+index 0000000..5bc9d79
+--- /dev/null
++++ b/units/isi/drv/imx662/CMakeLists.txt
+@@ -0,0 +1,122 @@
++cmake_minimum_required(VERSION 2.6)
++
++# define module name & interface version
++set (module imx662)
++
++# define interface version
++set (${module}_INTERFACE_CURRENT  1)
++set (${module}_INTERFACE_REVISION 0)
++set (${module}_INTERFACE_AGE      0)
++
++# we want to compile all .c files as default
++file(GLOB libsources source/IMX662.c )
++
++# set public headers, these get installed
++file(GLOB pub_headers include/*.h)
++
++# define include paths
++include_directories(
++    include
++    include_priv
++    ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include
++    )
++
++# module specific defines
++###add_definitions(-Wno-error=unused-function)
++
++# add lib to build env
++#add_library(${module}_static STATIC ${libsources})
++add_library(${module}_shared SHARED ${libsources})
++
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES OUTPUT_NAME     ${module})
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES LINK_FLAGS      -static)
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES OUTPUT_NAME     ${module})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES LINK_FLAGS      -shared)
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES SOVERSION       ${${module}_INTERFACE_CURRENT})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES VERSION         ${${module}_INTERFACE_CURRENT}.${${module}_INTERFACE_REVISION}.${${module}_INTERFACE_AGE})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++# add convenience target: put sensor driver into the 'bin' output dir as well
++if ( NOT ANDROID )
++add_custom_target(${module}.drv
++                  ALL
++                  COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${module}.drv
++                  DEPENDS ${module}_shared
++                  COMMENT "Copying ${module} driver module"
++                  )
++endif()
++
++# define lib dependencies
++#target_link_libraries(${module}_static
++#                      ${platform_libs}
++#                      ${base_libs}
++#                      ${drv_libs}
++#                      isi_shared
++#                      )
++
++# add link libs, or dlopen failed on Android
++if (ANDROID)
++if (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${platform_libs}
++                      ${base_libs}
++                      ${drv_libs}
++                      isi_shared
++                      )
++else (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${android_partial_platform_libs}
++                      ${android_partial_base_libs}
++                      ${android_partial_drv_libs}
++                      isi_shared
++                      )
++add_library(PrebuiltLibs SHARED IMPORTED)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libhal.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libbufferpool.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libcameric_drv.so)
++target_link_libraries(${module}_shared PRIVATE PrebuiltLibs)
++endif (GENERATE_PARTITION_BUILD)
++endif (ANDROID)
++
++# define stuff to install
++#install(TARGETS ${module}_static
++#        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++#        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
++#        )
++
++install(TARGETS ${module}_shared
++        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        LIBRARY         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        )
++
++# install the sensor driver as well, but to 'bin' location!
++install(FILES       ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT}
++        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++        RENAME      ${module}.drv
++        )
++
++if( DEFINED APPSHELL_TOP_COMPILE)
++add_custom_target(copy_shell_libs_${module} ALL
++       COMMENT "##Copy libs to shell libs"
++       COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so ${CMAKE_HOME_DIRECTORY}/shell_libs/ispcore/${PLATFORM}/lib${module}.so
++       #COMMAND ${CMAKE_COMMAND} -E copy_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/${module} ${CMAKE_HOME_DIRECTORY}/shell_libs/include/units_headers/${module}
++)
++add_dependencies(copy_shell_libs_${module} ${module}_shared)
++endif( DEFINED APPSHELL_TOP_COMPILE)
++
++if (NOT GENERATE_PARTITION_BUILD)
++add_custom_target(${module}_create_isi_dir
++                  COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/isi
++                  COMMENT "Create isi dir for ${module}")
++add_dependencies(${module}_create_isi_dir ${module}_shared)
++endif (NOT GENERATE_PARTITION_BUILD)
++
++unset(HEADER_CP_VAR)
++# create common targets for this module
++include(${UNITS_TOP_DIRECTORY}/targets.cmake)
++
++# create calib data targets
++add_subdirectory(calib)
+\ No newline at end of file
+diff --git a/units/isi/drv/imx662/Sensor0_Entry.cfg b/units/isi/drv/imx662/Sensor0_Entry.cfg
+new file mode 100644
+index 0000000..0403859
+--- /dev/null
++++ b/units/isi/drv/imx662/Sensor0_Entry.cfg
+@@ -0,0 +1,15 @@
++name = "imx662"
++drv = "IMX662.drv"
++mode = 0
++[mode.0]
++xml = "IMX662_Basic_1920x1080.xml"
++dwe = "dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json"
++[mode.1]
++xml = "IMX662_Basic_1280x720.xml"
++dwe = "dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json"
++[mode.2]
++xml = "IMX662_Basic_960x540.xml"
++dwe = "dewarp_config/sensor_dwe_IMX662_Basic_960x540.json"
++[mode.3]
++xml = "IMX662_Basic_640x480.xml"
++dwe = "dewarp_config/sensor_dwe_IMX662_Basic_640x480.json"
+diff --git a/units/isi/drv/imx662/Sensor1_Entry.cfg b/units/isi/drv/imx662/Sensor1_Entry.cfg
+new file mode 100644
+index 0000000..9dc6f27
+--- /dev/null
++++ b/units/isi/drv/imx662/Sensor1_Entry.cfg
+@@ -0,0 +1,15 @@
++name = "imx662"
++drv = "IMX662.drv"
++mode = 0
++[mode.0]
++xml = "IMX662.xml"
++dwe = "dewarp_config/sensor_dwe_imx662_1080p_config.json"
++[mode.1]
++xml = "IMX662_crop.xml"
++dwe = "dewarp_config/sensor_dwe_imx662_1080p_crop.json"
++[mode.2]
++xml = "IMX662_binning.xml"
++dwe = "dewarp_config/sensor_dwe_imx662_1080p_binning.json"
++[mode.3]
++xml = "IMX662_binning_crop.xml"
++dwe = "dewarp_config/sensor_dwe_imx662_1080p_binning_crop.json"
+diff --git a/units/isi/drv/imx662/calib/CMakeLists.txt b/units/isi/drv/imx662/calib/CMakeLists.txt
+new file mode 100644
+index 0000000..9944bca
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/CMakeLists.txt
+@@ -0,0 +1,44 @@
++cmake_minimum_required(VERSION 2.6)
++
++# use upper level module name
++
++# get calib data filenames
++file(GLOB_RECURSE calib_files *.xml)
++list(SORT calib_files)
++
++# a nice helper function
++function(add_calib_target ${calib_file})
++    # get calib data file's base name
++    get_filename_component(base_name ${calib_file} NAME_WE)
++
++    # add target to put sensor driver calibration data file into the 'bin' output and create a similar named symlink to the driver as well
++    add_custom_target(${base_name}_calib
++                      ALL
++                      COMMAND ${CMAKE_COMMAND} -E copy ${calib_file} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.xml
++                      #COMMAND ${CMAKE_COMMAND} -E create_symlink ${module}.drv ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.drv
++                      DEPENDS ${calib_file}
++                      COMMENT "Configuring ${base_name} calibration database"
++                      )
++
++#    add_dependencies(${module}_static
++#                     ${base_name}_calib
++#                     )
++
++    add_dependencies(${module}_shared
++                     ${base_name}_calib
++                     )
++
++    # install the sensor driver config & similar named driver symlink as well, but to 'bin' location!
++    install(FILES       ${calib_file}
++            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++            RENAME      ${base_name}.xml
++            )
++    install(CODE "${CMAKE_COMMAND} -E create_symlink ${module}.drv ${CMAKE_INSTALL_PREFIX}/bin/${base_name}.drv")
++endfunction(add_calib_target)
++
++# loop over all calib data files
++foreach(calib_file ${calib_files})
++    add_calib_target(calib_file)
++endforeach(calib_file)
++
++
+diff --git a/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1280x720.xml b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1280x720.xml
+new file mode 100644
+index 0000000..171f471
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1280x720.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX662
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 31]">
++         Basic_1280x720
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1280]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 720]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 8]">
++                  1280x720
++               </name>
++               <resolution index="1" type="char" size="[1 8]">
++                  1280x720
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.377265 0.453448 0.16929]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.722429 0.0317105 0.690718 0.380478 -0.815881 0.4354]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.923942 -0.382533 -2.3857]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.0168334 0.00867816 0.00113847 -0.00520983 -0.0106308 -0.0151969 -0.0186654 -0.0209561 -0.0220965 -0.0219136 -0.0203486 -0.017276 -0.0126376 -0.00615952 0.00204326 0.021531]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.0068334 0.00132184 0.00886153 0.0152098 0.0206308 0.0251969 0.0286654 0.0309561 0.0320965 0.0319136 0.0303486 0.027276 0.0226376 0.0161595 0.00795674 -0.011531]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.181277 0.162752 0.145807 0.130081 0.116211 0.103703 0.0930213 0.084579 0.0781971 0.0742299 0.0728297 0.0743474 0.0790814 0.0875527 0.0999388 0.13674]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0187228 0.0372484 0.0541927 0.0699188 0.0837894 0.0962966 0.106979 0.115421 0.121803 0.12577 0.12717 0.125653 0.120919 0.112447 0.100061 0.063261]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.1291]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.94]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.5917]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [1655.86 1747.05 1747.05 3104.2994]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 229.9837]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0412262 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 8]">
++                        1280x720
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        1280x720_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.15015 1 1 3.4203]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-26.8287 -29.2466 -34.8069]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_105
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [367.579 -5.33398 -5.33398 1266.0696]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 108.5703]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.18244 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 8]">
++                        1280x720
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1280x720_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.95205 1 1 1.621]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-27.6273 -28.2602 -32.482]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [557.808 359.254 359.254 1475.5552]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 132.588]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0346831 -0.029875]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 8]">
++                        1280x720
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1280x720_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.40512 1 1 2.6572]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-29.618 -33.7968 -31.8702]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               1280x720_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [66 76 78 78 84 84 86 88]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [43 46 44 45 46 46 46 44]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1280x720_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [66 76 78 78 84 84 86 88]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [43 46 44 45 46 46 46 44]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1280x720_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [66 76 78 78 84 84 86 88]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [43 46 44 45 46 46 46 44]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               1280x720_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [66 76 78 78 84 84 86 88]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [43 46 44 45 46 46 46 44]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_105
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 105]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-26.8287 -29.2466 -34.8069]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.15015 1 1 3.4203]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-27.6273 -28.2602 -32.482]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.95205 1 1 1.621]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-29.618 -33.7968 -31.8702]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.40512 1 1 2.6572]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.08814 -0.844023 -0.237191 -0.460044 1.60443 -0.0996407 0.00434868 -0.488471 1.5272]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.3746 -33.1455 -33.8914]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.68999 1 1 2.8635]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 15]">
++                  1280x720_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 15]">
++                  1280x720_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 15]">
++                  1280x720_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1920x1080.xml b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1920x1080.xml
+new file mode 100644
+index 0000000..1cb71e3
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1920x1080.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX662
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 32]">
++         Basic_1920x1080
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1920]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 1080]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  1920x1080
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  1920x1080
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.377265 0.453448 0.16929]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.722429 0.0317105 0.690718 0.380478 -0.815881 0.4354]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.923942 -0.382533 -2.3857]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.0168334 0.00867816 0.00113847 -0.00520983 -0.0106308 -0.0151969 -0.0186654 -0.0209561 -0.0220965 -0.0219136 -0.0203486 -0.017276 -0.0126376 -0.00615952 0.00204326 0.021531]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.0068334 0.00132184 0.00886153 0.0152098 0.0206308 0.0251969 0.0286654 0.0309561 0.0320965 0.0319136 0.0303486 0.027276 0.0226376 0.0161595 0.00795674 -0.011531]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.181277 0.162752 0.145807 0.130081 0.116211 0.103703 0.0930213 0.084579 0.0781971 0.0742299 0.0728297 0.0743474 0.0790814 0.0875527 0.0999388 0.13674]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0187228 0.0372484 0.0541927 0.0699188 0.0837894 0.0962966 0.106979 0.115421 0.121803 0.12577 0.12717 0.125653 0.120919 0.112447 0.100061 0.063261]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.1291]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.94]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.5917]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [1655.86 1747.05 1747.05 3104.2994]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 229.9837]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0412262 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1920x1080_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.15015 1 1 3.4203]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-26.8287 -29.2466 -34.8069]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_105
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [367.579 -5.33398 -5.33398 1266.0696]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 108.5703]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.18244 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1920x1080_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.95205 1 1 1.621]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-27.6273 -28.2602 -32.482]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [557.808 359.254 359.254 1475.5552]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 132.588]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0346831 -0.029875]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1920x1080_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.40512 1 1 2.6572]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-29.618 -33.7968 -31.8702]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1920x1080_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [75 93 104 114 130 141 147 156]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [56 63 64 68 72 72 73 72]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1920x1080_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [75 93 104 114 130 141 147 156]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [56 63 64 68 72 72 73 72]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1920x1080_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [75 93 104 114 130 141 147 156]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [56 63 64 68 72 72 73 72]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1920x1080_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [75 93 104 114 130 141 147 156]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [56 63 64 68 72 72 73 72]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_105
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 105]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-26.8287 -29.2466 -34.8069]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.15015 1 1 3.4203]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-27.6273 -28.2602 -32.482]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.95205 1 1 1.621]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-29.618 -33.7968 -31.8702]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.40512 1 1 2.6572]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.08814 -0.844023 -0.237191 -0.460044 1.60443 -0.0996407 0.00434868 -0.488471 1.5272]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.3746 -33.1455 -33.8914]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.68999 1 1 2.8635]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_640x480.xml b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_640x480.xml
+new file mode 100644
+index 0000000..3ff9e6b
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_640x480.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX662
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 30]">
++         Basic_640x480
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 640]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 480]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 7]">
++                  640x480
++               </name>
++               <resolution index="1" type="char" size="[1 7]">
++                  640x480
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.377265 0.453448 0.16929]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.722429 0.0317105 0.690718 0.380478 -0.815881 0.4354]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.923942 -0.382533 -2.3857]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.0168334 0.00867816 0.00113847 -0.00520983 -0.0106308 -0.0151969 -0.0186654 -0.0209561 -0.0220965 -0.0219136 -0.0203486 -0.017276 -0.0126376 -0.00615952 0.00204326 0.021531]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.0068334 0.00132184 0.00886153 0.0152098 0.0206308 0.0251969 0.0286654 0.0309561 0.0320965 0.0319136 0.0303486 0.027276 0.0226376 0.0161595 0.00795674 -0.011531]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.181277 0.162752 0.145807 0.130081 0.116211 0.103703 0.0930213 0.084579 0.0781971 0.0742299 0.0728297 0.0743474 0.0790814 0.0875527 0.0999388 0.13674]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0187228 0.0372484 0.0541927 0.0699188 0.0837894 0.0962966 0.106979 0.115421 0.121803 0.12577 0.12717 0.125653 0.120919 0.112447 0.100061 0.063261]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.1291]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.94]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.5917]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [1655.86 1747.05 1747.05 3104.2994]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 229.9837]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0412262 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        640x480
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 13]">
++                        640x480_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.15015 1 1 3.4203]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-26.8287 -29.2466 -34.8069]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_105
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [367.579 -5.33398 -5.33398 1266.0696]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 108.5703]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.18244 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        640x480
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        640x480_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.95205 1 1 1.621]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-27.6273 -28.2602 -32.482]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [557.808 359.254 359.254 1475.5552]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 132.588]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0346831 -0.029875]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        640x480
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        640x480_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.40512 1 1 2.6572]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-29.618 -33.7968 -31.8702]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 13]">
++               640x480_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [41 38 39 41 37 43 41 40]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [29 31 30 30 29 31 30 30]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               640x480_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [41 38 39 41 37 43 41 40]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [29 31 30 30 29 31 30 30]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               640x480_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [41 38 39 41 37 43 41 40]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [29 31 30 30 29 31 30 30]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 13]">
++               640x480_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [41 38 39 41 37 43 41 40]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [29 31 30 30 29 31 30 30]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_105
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 105]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-26.8287 -29.2466 -34.8069]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.15015 1 1 3.4203]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-27.6273 -28.2602 -32.482]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.95205 1 1 1.621]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-29.618 -33.7968 -31.8702]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.40512 1 1 2.6572]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.08814 -0.844023 -0.237191 -0.460044 1.60443 -0.0996407 0.00434868 -0.488471 1.5272]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.3746 -33.1455 -33.8914]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.68999 1 1 2.8635]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  640x480_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  640x480_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  640x480_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_960x540.xml b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_960x540.xml
+new file mode 100644
+index 0000000..60e12f2
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_960x540.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX662
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 30]">
++         Basic_960x540
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 960]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 540]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 7]">
++                  960x540
++               </name>
++               <resolution index="1" type="char" size="[1 7]">
++                  960x540
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.377265 0.453448 0.16929]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.722429 0.0317105 0.690718 0.380478 -0.815881 0.4354]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.923942 -0.382533 -2.3857]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.0168334 0.00867816 0.00113847 -0.00520983 -0.0106308 -0.0151969 -0.0186654 -0.0209561 -0.0220965 -0.0219136 -0.0203486 -0.017276 -0.0126376 -0.00615952 0.00204326 0.021531]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.0068334 0.00132184 0.00886153 0.0152098 0.0206308 0.0251969 0.0286654 0.0309561 0.0320965 0.0319136 0.0303486 0.027276 0.0226376 0.0161595 0.00795674 -0.011531]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.181277 0.162752 0.145807 0.130081 0.116211 0.103703 0.0930213 0.084579 0.0781971 0.0742299 0.0728297 0.0743474 0.0790814 0.0875527 0.0999388 0.13674]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0187228 0.0372484 0.0541927 0.0699188 0.0837894 0.0962966 0.106979 0.115421 0.121803 0.12577 0.12717 0.125653 0.120919 0.112447 0.100061 0.063261]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.1291]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.94]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.5917]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [1655.86 1747.05 1747.05 3104.2994]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 229.9837]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0412262 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        960x540
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 12]">
++                        960x540_A_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.15015 1 1 3.4203]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-26.8287 -29.2466 -34.8069]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_105
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [367.579 -5.33398 -5.33398 1266.0696]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 108.5703]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.18244 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        960x540
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        960x540_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.95205 1 1 1.621]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-27.6273 -28.2602 -32.482]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [557.808 359.254 359.254 1475.5552]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 132.588]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0346831 -0.029875]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        960x540
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        960x540_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.40512 1 1 2.6572]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-29.618 -33.7968 -31.8702]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 12]">
++               960x540_A_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [60 60 60 60 60 60 60 60]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [34 34 34 34 34 34 34 32]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               960x540_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [60 60 60 60 60 60 60 60]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [34 34 34 34 34 34 34 32]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               960x540_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [60 60 60 60 60 60 60 60]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [34 34 34 34 34 34 34 32]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 13]">
++               960x540_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [60 60 60 60 60 60 60 60]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [34 34 34 34 34 34 34 32]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_105
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 105]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-26.8287 -29.2466 -34.8069]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.15015 1 1 3.4203]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-27.6273 -28.2602 -32.482]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.95205 1 1 1.621]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-29.618 -33.7968 -31.8702]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.40512 1 1 2.6572]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.08814 -0.844023 -0.237191 -0.460044 1.60443 -0.0996407 0.00434868 -0.488471 1.5272]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.3746 -33.1455 -33.8914]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.68999 1 1 2.8635]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  960x540_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  960x540_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  960x540_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx662/source/IMX662.c b/units/isi/drv/imx662/source/IMX662.c
+new file mode 100644
+index 0000000..479744e
+--- /dev/null
++++ b/units/isi/drv/imx662/source/IMX662.c
+@@ -0,0 +1,1268 @@
++/******************************************************************************\
++|* Copyright (c) 2020 by VeriSilicon Holdings Co., Ltd. ("VeriSilicon")       *|
++|* All Rights Reserved.                                                       *|
++|*                                                                            *|
++|* The material in this file is confidential and contains trade secrets of    *|
++|* of VeriSilicon.  This is proprietary information owned or licensed by      *|
++|* VeriSilicon.  No part of this work may be disclosed, reproduced, copied,   *|
++|* transmitted, or used in any way for any purpose, without the express       *|
++|* written permission of VeriSilicon.                                         *|
++|*                                                                            *|
++\******************************************************************************/
++
++#include <ebase/types.h>
++#include <ebase/trace.h>
++#include <ebase/builtins.h>
++#include <common/return_codes.h>
++#include <common/misc.h>
++#include <sys/ioctl.h>
++#include <fcntl.h>
++#include "isi.h"
++#include "isi_iss.h"
++#include "isi_priv.h"
++#include "vvsensor.h"
++
++CREATE_TRACER( IMX662_INFO , "IMX662: ", INFO,    1);
++CREATE_TRACER( IMX662_WARN , "IMX662: ", WARNING, 1);
++CREATE_TRACER( IMX662_ERROR, "IMX662: ", ERROR,   1);
++
++#ifdef SUBDEV_V4L2
++#include <sys/ioctl.h>
++#include <sys/mman.h>
++#include <fcntl.h>
++#include <linux/videodev2.h>
++#include <linux/v4l2-subdev.h>
++//#undef TRACE
++//#define TRACE(x, ...)
++#endif
++
++static const char SensorName[16] = "imx662";
++
++typedef struct IMX662_Context_s
++{
++    IsiSensorContext_t  IsiCtx;
++    struct vvcam_mode_info_s CurMode;
++    IsiSensorAeInfo_t AeInfo;
++    IsiSensorIntTime_t IntTime;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    IsiSensorGain_t SensorGain;
++    uint32_t minAfps;
++    uint64_t AEStartExposure;
++} IMX662_Context_t;
++
++static RESULT IMX662_IsiSensorSetPowerIss(IsiSensorHandle_t handle, bool_t on)
++{
++    int ret = 0;
++
++    TRACE( IMX662_INFO, "%s: (enter)\n", __func__);
++    TRACE( IMX662_INFO, "%s: set power %d\n", __func__,on);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    int32_t power = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_POWER, &power);
++    if (ret != 0){
++        TRACE(IMX662_ERROR, "%s set power %d error\n", __func__,power);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorGetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (!pclk)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CLK, pclk);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s get clock error\n", __func__);
++        return RET_FAILURE;
++    } 
++    
++    TRACE( IMX662_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++    TRACE( IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorSetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pclk == NULL)
++        return RET_NULL_POINTER;
++    
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_CLK, &pclk);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX662_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++
++    TRACE( IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiResetSensorIss(IsiSensorHandle_t handle)
++{
++    int ret = 0;
++
++    TRACE( IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_RESET, NULL);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s set reset error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiRegisterReadIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        uint32_t * pValue)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_READ_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: read sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    *pValue = sccb_data.data;
++
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiRegisterWriteIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        const uint32_t value)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = value;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_WRITE_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: write sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_UpdateIsiAEInfo(IsiSensorHandle_t handle)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    IsiSensorAeInfo_t *pAeInfo = &pIMX662Ctx->AeInfo;
++    pAeInfo->oneLineExpTime = pIMX662Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++
++    if (pIMX662Ctx->CurMode.hdr_mode == SENSOR_MODE_LINEAR) {
++        pAeInfo->maxIntTime.linearInt =
++            pIMX662Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->minIntTime.linearInt =
++            pIMX662Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->maxAGain.linearGainParas = pIMX662Ctx->CurMode.ae_info.max_again;
++        pAeInfo->minAGain.linearGainParas = pIMX662Ctx->CurMode.ae_info.min_again;
++        pAeInfo->maxDGain.linearGainParas = pIMX662Ctx->CurMode.ae_info.max_dgain;
++        pAeInfo->minDGain.linearGainParas = pIMX662Ctx->CurMode.ae_info.min_dgain;
++    } else {
++        switch (pIMX662Ctx->CurMode.stitching_mode) {
++            case SENSOR_STITCHING_DUAL_DCG:
++            case SENSOR_STITCHING_3DOL:
++            case SENSOR_STITCHING_LINEBYLINE:
++                pAeInfo->maxIntTime.triInt.triSIntTime =
++                    pIMX662Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triSIntTime =
++                    pIMX662Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                
++                pAeInfo->maxIntTime.triInt.triIntTime =
++                    pIMX662Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triIntTime =
++                    pIMX662Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX662Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG) {
++                    pAeInfo->maxIntTime.triInt.triLIntTime = pAeInfo->maxIntTime.triInt.triIntTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime = pAeInfo->minIntTime.triInt.triIntTime;
++                } else {
++                    pAeInfo->maxIntTime.triInt.triLIntTime =
++                        pIMX662Ctx->CurMode.ae_info.max_longintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime =
++                        pIMX662Ctx->CurMode.ae_info.min_longintegration_line * pAeInfo->oneLineExpTime;
++                }
++
++                pAeInfo->maxAGain.triGainParas.triSGain = pIMX662Ctx->CurMode.ae_info.max_short_again;
++                pAeInfo->minAGain.triGainParas.triSGain = pIMX662Ctx->CurMode.ae_info.min_short_again;
++                pAeInfo->maxDGain.triGainParas.triSGain = pIMX662Ctx->CurMode.ae_info.max_short_dgain;
++                pAeInfo->minDGain.triGainParas.triSGain = pIMX662Ctx->CurMode.ae_info.min_short_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triGain = pIMX662Ctx->CurMode.ae_info.max_again;
++                pAeInfo->minAGain.triGainParas.triGain = pIMX662Ctx->CurMode.ae_info.min_again;
++                pAeInfo->maxDGain.triGainParas.triGain = pIMX662Ctx->CurMode.ae_info.max_dgain;
++                pAeInfo->minDGain.triGainParas.triGain = pIMX662Ctx->CurMode.ae_info.min_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triLGain = pIMX662Ctx->CurMode.ae_info.max_long_again;
++                pAeInfo->minAGain.triGainParas.triLGain = pIMX662Ctx->CurMode.ae_info.min_long_again;
++                pAeInfo->maxDGain.triGainParas.triLGain = pIMX662Ctx->CurMode.ae_info.max_long_dgain;
++                pAeInfo->minDGain.triGainParas.triLGain = pIMX662Ctx->CurMode.ae_info.min_long_dgain;
++                break;
++            case SENSOR_STITCHING_DUAL_DCG_NOWAIT:
++            case SENSOR_STITCHING_16BIT_COMPRESS:
++            case SENSOR_STITCHING_L_AND_S:
++            case SENSOR_STITCHING_2DOL:
++                pAeInfo->maxIntTime.dualInt.dualIntTime =
++                    pIMX662Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.dualInt.dualIntTime =
++                    pIMX662Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX662Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime = pAeInfo->maxIntTime.dualInt.dualIntTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime = pAeInfo->minIntTime.dualInt.dualIntTime;
++                } else {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime =
++                        pIMX662Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime =
++                        pIMX662Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                }
++                
++                if (pIMX662Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.min_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.max_long_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.min_long_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.max_long_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.min_long_dgain;
++                } else {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.max_short_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.min_short_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.max_short_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.min_short_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.min_dgain;
++                }
++                
++                break;
++            default:
++                break;
++        }
++    }
++    pAeInfo->gainStep = pIMX662Ctx->CurMode.ae_info.gain_step;
++    pAeInfo->currFps  = pIMX662Ctx->CurMode.ae_info.cur_fps;
++    pAeInfo->maxFps   = pIMX662Ctx->CurMode.ae_info.max_fps;
++    pAeInfo->minFps   = pIMX662Ctx->CurMode.ae_info.min_fps;
++    pAeInfo->minAfps  = pIMX662Ctx->CurMode.ae_info.min_afps;
++    pAeInfo->hdrRatio[0] = pIMX662Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s;
++    pAeInfo->hdrRatio[1] = pIMX662Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs;
++
++    pAeInfo->intUpdateDlyFrm = pIMX662Ctx->CurMode.ae_info.int_update_delay_frm;
++    pAeInfo->gainUpdateDlyFrm = pIMX662Ctx->CurMode.ae_info.gain_update_delay_frm;
++
++    if (pIMX662Ctx->minAfps != 0) {
++        pAeInfo->minAfps = pIMX662Ctx->minAfps;
++    } 
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    memcpy(pMode, &pIMX662Ctx->CurMode, sizeof(IsiSensorMode_t));
++
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    struct vvcam_mode_info_s sensor_mode;
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    sensor_mode.index = pMode->index;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s set sensor mode failed", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX662Ctx->CurMode, &sensor_mode, sizeof(struct vvcam_mode_info_s));
++    IMX662_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorSetStreamingIss(IsiSensorHandle_t handle,
++                                              bool_t on)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    uint32_t status = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_STREAM, &status);
++    if (ret != 0){
++        TRACE(IMX662_ERROR, "%s set sensor stream %d error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: set streaming %d\n", __func__, on);
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiCreateSensorIss(IsiSensorInstanceConfig_t * pConfig)
++{
++    RESULT result = RET_SUCCESS;
++    IMX662_Context_t *pIMX662Ctx;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    if (!pConfig || !pConfig->pSensor || !pConfig->HalHandle)
++        return RET_NULL_POINTER;
++
++    pIMX662Ctx = (IMX662_Context_t *) malloc(sizeof(IMX662_Context_t));
++    if (!pIMX662Ctx)
++        return RET_OUTOFMEM;
++
++    memset(pIMX662Ctx, 0, sizeof(IMX662_Context_t));
++    pIMX662Ctx->IsiCtx.HalHandle = pConfig->HalHandle;
++    pIMX662Ctx->IsiCtx.pSensor   = pConfig->pSensor;
++    pConfig->hSensor = (IsiSensorHandle_t) pIMX662Ctx;
++
++    result = IMX662_IsiSensorSetPowerIss(pIMX662Ctx, BOOL_TRUE);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s set power error\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    result = IMX662_IsiSensorGetClkIss(pIMX662Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s get clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    clk.status = 1;
++    result = IMX662_IsiSensorSetClkIss(pIMX662Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    result = IMX662_IsiResetSensorIss(pIMX662Ctx);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s retset sensor error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    IsiSensorMode_t SensorMode;
++    SensorMode.index = pConfig->SensorModeIndex;
++    result = IMX662_IsiSetSensorModeIss(pIMX662Ctx, &SensorMode);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX662_IsiReleaseSensorIss(IsiSensorHandle_t handle)
++{
++    TRACE(IMX662_INFO, "%s (enter) \n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    if (pIMX662Ctx == NULL)
++        return (RET_WRONG_HANDLE);
++
++    IMX662_IsiSensorSetStreamingIss(pIMX662Ctx, BOOL_FALSE);
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    IMX662_IsiSensorGetClkIss(pIMX662Ctx, &clk);
++    clk.status = 0;
++    IMX662_IsiSensorSetClkIss(pIMX662Ctx, &clk);
++    IMX662_IsiSensorSetPowerIss(pIMX662Ctx, BOOL_FALSE);
++    free(pIMX662Ctx);
++    pIMX662Ctx = NULL;
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiHalQuerySensorIss(HalHandle_t HalHandle,
++                                          IsiSensorModeInfoArray_t *pSensorMode)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter) \n", __func__);
++
++    if (HalHandle == NULL || pSensorMode == NULL)
++        return RET_NULL_POINTER;
++
++    HalContext_t *pHalCtx = (HalContext_t *)HalHandle;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_QUERY, pSensorMode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiQuerySensorIss(IsiSensorHandle_t handle,
++                                       IsiSensorModeInfoArray_t *pSensorMode)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX662_INFO, "%s (enter) \n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    result = IMX662_IsiHalQuerySensorIss(pIMX662Ctx->IsiCtx.HalHandle,
++                                         pSensorMode);
++    if (result != RET_SUCCESS)
++        TRACE(IMX662_ERROR, "%s: query sensor mode info error!\n", __func__);
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX662_IsiGetCapsIss(IsiSensorHandle_t handle,
++                                   IsiSensorCaps_t * pIsiSensorCaps)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX662_INFO, "%s (enter) \n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    IsiSensorModeInfoArray_t SensorModeInfo;
++    memset(&SensorModeInfo, 0, sizeof(IsiSensorModeInfoArray_t));
++    result = IMX662_IsiQuerySensorIss(handle, &SensorModeInfo);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    pIsiSensorCaps->FieldSelection    = ISI_FIELDSEL_BOTH;
++    pIsiSensorCaps->YCSequence        = ISI_YCSEQ_YCBYCR;
++    pIsiSensorCaps->Conv422           = ISI_CONV422_NOCOSITED;
++    pIsiSensorCaps->HPol              = ISI_HPOL_REFPOS;
++    pIsiSensorCaps->VPol              = ISI_VPOL_NEG;
++    pIsiSensorCaps->Edge              = ISI_EDGE_RISING;
++    pIsiSensorCaps->supportModeNum    = SensorModeInfo.count;
++    pIsiSensorCaps->currentMode       = pIMX662Ctx->CurMode.index;
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX662_IsiSetupSensorIss(IsiSensorHandle_t handle,
++                                       const IsiSensorCaps_t *pIsiSensorCaps )
++{
++    int ret = 0;
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    if (pIsiSensorCaps->currentMode != pIMX662Ctx->CurMode.index) {
++        IsiSensorMode_t SensorMode;
++        memset(&SensorMode, 0, sizeof(IsiSensorMode_t));
++        SensorMode.index = pIsiSensorCaps->currentMode;
++        result = IMX662_IsiSetSensorModeIss(handle, &SensorMode);
++        if (result != RET_SUCCESS) {
++            TRACE(IMX662_ERROR, "%s:set sensor mode %d failed!\n",
++                  __func__, SensorMode.index);
++            return result;
++        }
++    }
++
++#ifdef SUBDEV_V4L2
++    struct v4l2_subdev_format format;
++    memset(&format, 0, sizeof(struct v4l2_subdev_format));
++    format.format.width  = pIMX662Ctx->CurMode.size.bounds_width;
++    format.format.height = pIMX662Ctx->CurMode.size.bounds_height;
++    format.which = V4L2_SUBDEV_FORMAT_ACTIVE;
++    format.pad = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VIDIOC_SUBDEV_S_FMT, &format);
++    if (ret != 0){
++        TRACE(IMX662_ERROR, "%s: sensor set format error!\n", __func__);
++        return RET_FAILURE;
++    }
++#else
++    ret = ioctrl(pHalCtx->sensor_fd, VVSENSORIOC_S_INIT, NULL);
++    if (ret != 0){
++        TRACE(IMX662_ERROR, "%s: sensor init error!\n", __func__);
++        return RET_FAILURE;
++    }
++#endif
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetSensorRevisionIss(IsiSensorHandle_t handle, uint32_t *pValue)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pValue == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CHIP_ID, pValue);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: get chip id error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiCheckSensorConnectionIss(IsiSensorHandle_t handle)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    uint32_t ChipId = 0;
++    result = IMX662_IsiGetSensorRevisionIss(handle, &ChipId);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s:get sensor chip id error!\n",__func__);
++        return RET_FAILURE;
++    }
++
++    if (ChipId != 662) {
++        TRACE(IMX662_ERROR,
++            "%s:ChipID=662,while read sensor Id=0x%x error!\n",
++             __func__, ChipId);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetAeInfoIss(IsiSensorHandle_t handle,
++                                     IsiSensorAeInfo_t *pAeInfo)
++{
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    if (pAeInfo == NULL)
++        return RET_NULL_POINTER;
++
++    memcpy(pAeInfo, &pIMX662Ctx->AeInfo, sizeof(IsiSensorAeInfo_t));
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetHdrRatioIss(IsiSensorHandle_t handle,
++                                       uint8_t hdrRatioNum,
++                                       uint32_t HdrRatio[])
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    struct sensor_hdr_artio_s hdr_ratio;
++    if (hdrRatioNum == 2) {
++        hdr_ratio.ratio_s_vs = HdrRatio[1];
++        hdr_ratio.ratio_l_s = HdrRatio[0];
++    }else {
++        hdr_ratio.ratio_s_vs = HdrRatio[0];
++        hdr_ratio.ratio_l_s = 0;
++    }
++
++    if (hdr_ratio.ratio_s_vs == pIMX662Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs &&
++        hdr_ratio.ratio_l_s == pIMX662Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s)
++        return RET_SUCCESS;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_HDR_RADIO, &hdr_ratio);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR,"%s: set hdr ratio error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s sensor_mode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR,"%s: get mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memcpy(&pIMX662Ctx->CurMode, &sensor_mode, sizeof (struct vvcam_mode_info_s));
++    IMX662_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    memcpy(pIntegrationTime, &pIMX662Ctx->IntTime, sizeof(IsiSensorIntTime_t));
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++
++}
++
++static RESULT IMX662_IsiSetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    int ret = 0;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    uint32_t oneLineTime;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++    printf("\n\nAAAAAAAAAAAAAAA %u\n\n", pIntegrationTime->IntegrationTime.linearInt);
++    if (pIntegrationTime == NULL)
++        return RET_NULL_POINTER;
++
++    oneLineTime =  pIMX662Ctx->AeInfo.oneLineExpTime;
++    pIMX662Ctx->IntTime.expoFrmType = pIntegrationTime->expoFrmType;
++
++    switch (pIntegrationTime->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            IntLine = pIntegrationTime->IntegrationTime.linearInt;
++            if (IntLine != pIMX662Ctx->IntLine) {
++                printf("\n\ngoing into S_EXP ioctl %u\n\n", IntLine);
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor linear exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++               pIMX662Ctx->IntLine = IntLine;
++            }
++            TRACE(IMX662_INFO, "%s set linear exp %d \n", __func__,IntLine);
++            pIMX662Ctx->IntTime.IntegrationTime.linearInt =  IntLine * oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            IntLine = pIntegrationTime->IntegrationTime.dualInt.dualIntTime;
++            if (IntLine != pIMX662Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor dual exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX662Ctx->IntLine = IntLine;
++            }
++
++            if (pIMX662Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                ShortIntLine = pIntegrationTime->IntegrationTime.dualInt.dualSIntTime;
++                if (ShortIntLine != pIMX662Ctx->ShortIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX662_ERROR,"%s:set sensor dual vsexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX662Ctx->ShortIntLine = ShortIntLine;
++                }
++            } else {
++                ShortIntLine = IntLine;
++                pIMX662Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX662_INFO, "%s set dual exp %d short_exp %d\n", __func__, IntLine, ShortIntLine);
++            pIMX662Ctx->IntTime.IntegrationTime.dualInt.dualIntTime  = IntLine + oneLineTime;
++            pIMX662Ctx->IntTime.IntegrationTime.dualInt.dualSIntTime = ShortIntLine + oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            if (pIMX662Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triLIntTime;
++                if (LongIntLine != pIMX662Ctx->LongIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_EXP, &LongIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX662_ERROR,"%s:set sensor tri lexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX662Ctx->LongIntLine = LongIntLine;
++                }
++            } else {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++                pIMX662Ctx->LongIntLine = LongIntLine;
++            }
++
++            IntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++            if (IntLine != pIMX662Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX662Ctx->IntLine = IntLine;
++            }
++            
++            ShortIntLine = pIntegrationTime->IntegrationTime.triInt.triSIntTime;
++            if (ShortIntLine != pIMX662Ctx->ShortIntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri vsexp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX662Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX662_INFO, "%s set tri long exp %d exp %d short_exp %d\n", __func__, LongIntLine, IntLine, ShortIntLine);
++            pIMX662Ctx->IntTime.IntegrationTime.triInt.triLIntTime = LongIntLine + oneLineTime;
++            pIMX662Ctx->IntTime.IntegrationTime.triInt.triIntTime = IntLine + oneLineTime;
++            pIMX662Ctx->IntTime.IntegrationTime.triInt.triSIntTime = ShortIntLine + oneLineTime;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++    
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++    memcpy(pGain, &pIMX662Ctx->SensorGain, sizeof(IsiSensorGain_t));
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    int ret = 0;
++    uint32_t LongGain;
++    uint32_t Gain;
++    uint32_t ShortGain;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++
++    pIMX662Ctx->SensorGain.expoFrmType = pGain->expoFrmType;
++    switch (pGain->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            Gain = pGain->gain.linearGainParas;
++            if (pIMX662Ctx->SensorGain.gain.linearGainParas != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor linear gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            pIMX662Ctx->SensorGain.gain.linearGainParas = pGain->gain.linearGainParas;
++            TRACE(IMX662_INFO, "%s set linear gain %d\n", __func__,pGain->gain.linearGainParas);
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            Gain = pGain->gain.dualGainParas.dualGain;
++            if (pIMX662Ctx->SensorGain.gain.dualGainParas.dualGain != Gain) {
++                if (pIMX662Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &Gain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor dual gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.dualGainParas.dualSGain;
++            if (pIMX662Ctx->SensorGain.gain.dualGainParas.dualSGain != ShortGain) {
++                if (pIMX662Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &ShortGain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor dual vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX662_INFO,"%s:set gain%d short gain %d!\n", __func__,Gain,ShortGain);
++            pIMX662Ctx->SensorGain.gain.dualGainParas.dualGain = Gain;
++            pIMX662Ctx->SensorGain.gain.dualGainParas.dualSGain = ShortGain;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            LongGain = pGain->gain.triGainParas.triLGain;
++            if (pIMX662Ctx->SensorGain.gain.triGainParas.triLGain != LongGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &LongGain);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            Gain = pGain->gain.triGainParas.triGain;
++            if (pIMX662Ctx->SensorGain.gain.triGainParas.triGain != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.triGainParas.triSGain;
++            if (pIMX662Ctx->SensorGain.gain.triGainParas.triSGain != ShortGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX662_INFO,"%s:set long gain %d gain%d short gain %d!\n", __func__, LongGain, Gain, ShortGain);
++            pIMX662Ctx->SensorGain.gain.triGainParas.triLGain = LongGain;
++            pIMX662Ctx->SensorGain.gain.triGainParas.triGain = Gain;
++            pIMX662Ctx->SensorGain.gain.triGainParas.triSGain = ShortGain;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++
++static RESULT IMX662_IsiGetSensorFpsIss(IsiSensorHandle_t handle, uint32_t * pfps)
++{
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    if (pfps == NULL)
++        return RET_NULL_POINTER;
++
++    *pfps = pIMX662Ctx->CurMode.ae_info.cur_fps;
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetSensorFpsIss(IsiSensorHandle_t handle, uint32_t fps)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_FPS, &fps);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR,"%s:set sensor fps error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s SensorMode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &SensorMode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR,"%s:get sensor mode error!\n", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX662Ctx->CurMode, &SensorMode, sizeof(struct vvcam_mode_info_s));
++    IMX662_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++static RESULT IMX662_IsiSetSensorAfpsLimitsIss(IsiSensorHandle_t handle, uint32_t minAfps)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    if ((minAfps > pIMX662Ctx->CurMode.ae_info.max_fps) ||
++        (minAfps < pIMX662Ctx->CurMode.ae_info.min_fps))
++        return RET_FAILURE;
++    pIMX662Ctx->minAfps = minAfps;
++    pIMX662Ctx->CurMode.ae_info.min_afps = minAfps;
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetSensorIspStatusIss(IsiSensorHandle_t handle,
++                               IsiSensorIspStatus_t *pSensorIspStatus)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    if (pIMX662Ctx->CurMode.hdr_mode == SENSOR_MODE_HDR_NATIVE) {
++        pSensorIspStatus->useSensorAWB = true;
++        pSensorIspStatus->useSensorBLC = true;
++    } else {
++        pSensorIspStatus->useSensorAWB = false;
++        pSensorIspStatus->useSensorBLC = false;
++    }
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++#ifndef ISI_LITE
++static RESULT IMX662_IsiSensorSetBlcIss(IsiSensorHandle_t handle, IsiSensorBlc_t * pBlc)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pBlc == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_blc_s SensorBlc;
++    SensorBlc.red = pBlc->red;
++    SensorBlc.gb = pBlc->gb;
++    SensorBlc.gr = pBlc->gr;
++    SensorBlc.blue = pBlc->blue;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_BLC, &SensorBlc);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorSetWBIss(IsiSensorHandle_t handle, IsiSensorWB_t *pWb)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pWb == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_white_balance_s SensorWb;
++    SensorWb.r_gain = pWb->r_gain;
++    SensorWb.gr_gain = pWb->gr_gain;
++    SensorWb.gb_gain = pWb->gb_gain;
++    SensorWb.b_gain = pWb->b_gain;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_WB, &SensorWb);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorGetExpandCurveIss(IsiSensorHandle_t handle, IsiSensorExpandCurve_t *pExpandCurve)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pExpandCurve == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_EXPAND_CURVE, pExpandCurve);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: get  expand cure error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetTestPatternIss(IsiSensorHandle_t handle,
++                                       IsiSensorTpgMode_e  tpgMode)
++{
++    int32_t ret = 0;
++
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    struct sensor_test_pattern_s TestPattern;
++    if (tpgMode == ISI_TPG_DISABLE) {
++        TestPattern.enable = 0;
++        TestPattern.pattern = 0;
++    } else {
++        TestPattern.enable = 1;
++        TestPattern.pattern = (uint32_t)tpgMode - 1;
++    }
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_TEST_PATTERN, &TestPattern);
++    if (ret != 0)
++    {
++        TRACE(IMX662_ERROR, "%s: set test pattern %d error\n", __func__, tpgMode);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: test pattern enable[%d] mode[%d]\n", __func__, TestPattern.enable, TestPattern.pattern);
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiFocusSetupIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiFocusReleaseIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiFocusGetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiFocusSetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetFocusCalibrateIss(IsiSensorHandle_t handle, IsiFoucsCalibAttr_t *pFocusCalib)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t *pExposure)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    if (pIMX662Ctx->AEStartExposure == 0) {
++        pIMX662Ctx->AEStartExposure =
++            (uint64_t)pIMX662Ctx->CurMode.ae_info.start_exposure *
++            pIMX662Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++           
++    }
++    *pExposure =  pIMX662Ctx->AEStartExposure;
++    TRACE(IMX662_INFO, "%s:get start exposure %d\n", __func__, pIMX662Ctx->AEStartExposure);
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t exposure)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    pIMX662Ctx->AEStartExposure = exposure;
++    TRACE(IMX662_INFO, "set start exposure %d\n", __func__,pIMX662Ctx->AEStartExposure);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++#endif
++
++RESULT IMX662_IsiGetSensorIss(IsiSensor_t *pIsiSensor)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++
++    if (pIsiSensor == NULL)
++        return RET_NULL_POINTER;
++     pIsiSensor->pszName                         = SensorName;
++     pIsiSensor->pIsiSensorSetPowerIss           = IMX662_IsiSensorSetPowerIss;
++     pIsiSensor->pIsiCreateSensorIss             = IMX662_IsiCreateSensorIss;
++     pIsiSensor->pIsiReleaseSensorIss            = IMX662_IsiReleaseSensorIss;
++     pIsiSensor->pIsiRegisterReadIss             = IMX662_IsiRegisterReadIss;
++     pIsiSensor->pIsiRegisterWriteIss            = IMX662_IsiRegisterWriteIss;
++     pIsiSensor->pIsiGetSensorModeIss            = IMX662_IsiGetSensorModeIss;
++     pIsiSensor->pIsiSetSensorModeIss            = IMX662_IsiSetSensorModeIss;
++     pIsiSensor->pIsiQuerySensorIss              = IMX662_IsiQuerySensorIss;
++     pIsiSensor->pIsiGetCapsIss                  = IMX662_IsiGetCapsIss;
++     pIsiSensor->pIsiSetupSensorIss              = IMX662_IsiSetupSensorIss;
++     pIsiSensor->pIsiGetSensorRevisionIss        = IMX662_IsiGetSensorRevisionIss;
++     pIsiSensor->pIsiCheckSensorConnectionIss    = IMX662_IsiCheckSensorConnectionIss;
++     pIsiSensor->pIsiSensorSetStreamingIss       = IMX662_IsiSensorSetStreamingIss;
++     pIsiSensor->pIsiGetAeInfoIss                = IMX662_IsiGetAeInfoIss;
++     pIsiSensor->pIsiSetHdrRatioIss              = IMX662_IsiSetHdrRatioIss;
++     pIsiSensor->pIsiGetIntegrationTimeIss       = IMX662_IsiGetIntegrationTimeIss;
++     pIsiSensor->pIsiSetIntegrationTimeIss       = IMX662_IsiSetIntegrationTimeIss;
++     pIsiSensor->pIsiGetGainIss                  = IMX662_IsiGetGainIss;
++     pIsiSensor->pIsiSetGainIss                  = IMX662_IsiSetGainIss;
++     pIsiSensor->pIsiGetSensorFpsIss             = IMX662_IsiGetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorFpsIss             = IMX662_IsiSetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorAfpsLimitsIss      = IMX662_IsiSetSensorAfpsLimitsIss;
++     pIsiSensor->pIsiGetSensorIspStatusIss       = IMX662_IsiGetSensorIspStatusIss;
++#ifndef ISI_LITE
++    pIsiSensor->pIsiSensorSetBlcIss              = IMX662_IsiSensorSetBlcIss;
++    pIsiSensor->pIsiSensorSetWBIss               = IMX662_IsiSensorSetWBIss;
++    pIsiSensor->pIsiSensorGetExpandCurveIss      = IMX662_IsiSensorGetExpandCurveIss;
++    pIsiSensor->pIsiActivateTestPatternIss       = IMX662_IsiSetTestPatternIss;
++    pIsiSensor->pIsiFocusSetupIss                = IMX662_IsiFocusSetupIss;
++    pIsiSensor->pIsiFocusReleaseIss              = IMX662_IsiFocusReleaseIss;
++    pIsiSensor->pIsiFocusSetIss                  = IMX662_IsiFocusSetIss;
++    pIsiSensor->pIsiFocusGetIss                  = IMX662_IsiFocusGetIss;
++    pIsiSensor->pIsiGetFocusCalibrateIss         = IMX662_IsiGetFocusCalibrateIss;
++    pIsiSensor->pIsiSetAeStartExposureIss        = IMX662_IsiSetAeStartExposureIs;
++    pIsiSensor->pIsiGetAeStartExposureIss        = IMX662_IsiGetAeStartExposureIs;
++#endif
++    TRACE( IMX662_INFO, "%s (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++/*****************************************************************************
++* each sensor driver need declare this struct for isi load
++*****************************************************************************/
++IsiCamDrvConfig_t IsiCamDrvConfig = {
++    .CameraDriverID = 0x0662,
++    .pIsiHalQuerySensor = IMX662_IsiHalQuerySensorIss,
++    .pfIsiGetSensorIss = IMX662_IsiGetSensorIss,
++};
+diff --git a/units/isi/drv/imx676/CMakeLists.txt b/units/isi/drv/imx676/CMakeLists.txt
+new file mode 100755
+index 0000000..614e337
+--- /dev/null
++++ b/units/isi/drv/imx676/CMakeLists.txt
+@@ -0,0 +1,122 @@
++cmake_minimum_required(VERSION 2.6)
++
++# define module name & interface version
++set (module imx676)
++
++# define interface version
++set (${module}_INTERFACE_CURRENT  1)
++set (${module}_INTERFACE_REVISION 0)
++set (${module}_INTERFACE_AGE      0)
++
++# we want to compile all .c files as default
++file(GLOB libsources source/IMX676.c )
++
++# set public headers, these get installed
++file(GLOB pub_headers include/*.h)
++
++# define include paths
++include_directories(
++    include
++    include_priv
++    ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include
++    )
++
++# module specific defines
++###add_definitions(-Wno-error=unused-function)
++
++# add lib to build env
++#add_library(${module}_static STATIC ${libsources})
++add_library(${module}_shared SHARED ${libsources})
++
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES OUTPUT_NAME     ${module})
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES LINK_FLAGS      -static)
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES OUTPUT_NAME     ${module})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES LINK_FLAGS      -shared)
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES SOVERSION       ${${module}_INTERFACE_CURRENT})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES VERSION         ${${module}_INTERFACE_CURRENT}.${${module}_INTERFACE_REVISION}.${${module}_INTERFACE_AGE})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++# add convenience target: put sensor driver into the 'bin' output dir as well
++if ( NOT ANDROID )
++add_custom_target(${module}.drv
++                  ALL
++                  COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${module}.drv
++                  DEPENDS ${module}_shared
++                  COMMENT "Copying ${module} driver module"
++                  )
++endif()
++
++# define lib dependencies
++#target_link_libraries(${module}_static
++#                      ${platform_libs}
++#                      ${base_libs}
++#                      ${drv_libs}
++#                      isi_shared
++#                      )
++
++# add link libs, or dlopen failed on Android
++if (ANDROID)
++if (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${platform_libs}
++                      ${base_libs}
++                      ${drv_libs}
++                      isi_shared
++                      )
++else (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${android_partial_platform_libs}
++                      ${android_partial_base_libs}
++                      ${android_partial_drv_libs}
++                      isi_shared
++                      )
++add_library(PrebuiltLibs SHARED IMPORTED)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libhal.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libbufferpool.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libcameric_drv.so)
++target_link_libraries(${module}_shared PRIVATE PrebuiltLibs)
++endif (GENERATE_PARTITION_BUILD)
++endif (ANDROID)
++
++# define stuff to install
++#install(TARGETS ${module}_static
++#        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++#        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
++#        )
++
++install(TARGETS ${module}_shared
++        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        LIBRARY         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        )
++
++# install the sensor driver as well, but to 'bin' location!
++install(FILES       ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT}
++        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++        RENAME      ${module}.drv
++        )
++
++if( DEFINED APPSHELL_TOP_COMPILE)
++add_custom_target(copy_shell_libs_${module} ALL
++       COMMENT "##Copy libs to shell libs"
++       COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so ${CMAKE_HOME_DIRECTORY}/shell_libs/ispcore/${PLATFORM}/lib${module}.so
++       #COMMAND ${CMAKE_COMMAND} -E copy_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/${module} ${CMAKE_HOME_DIRECTORY}/shell_libs/include/units_headers/${module}
++)
++add_dependencies(copy_shell_libs_${module} ${module}_shared)
++endif( DEFINED APPSHELL_TOP_COMPILE)
++
++if (NOT GENERATE_PARTITION_BUILD)
++add_custom_target(${module}_create_isi_dir
++                  COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/isi
++                  COMMENT "Create isi dir for ${module}")
++add_dependencies(${module}_create_isi_dir ${module}_shared)
++endif (NOT GENERATE_PARTITION_BUILD)
++
++unset(HEADER_CP_VAR)
++# create common targets for this module
++include(${UNITS_TOP_DIRECTORY}/targets.cmake)
++
++# create calib data targets
++add_subdirectory(calib)
+\ No newline at end of file
+diff --git a/units/isi/drv/imx676/Sensor0_Entry.cfg b/units/isi/drv/imx676/Sensor0_Entry.cfg
+new file mode 100644
+index 0000000..db22ccf
+--- /dev/null
++++ b/units/isi/drv/imx676/Sensor0_Entry.cfg
+@@ -0,0 +1,16 @@
++name = "imx676"
++drv = "imx676.drv"
++mode = 0
++[mode.0]
++xml = "IMX676_Basic_3536x3072.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json"
++[mode.1]
++xml = "IMX676_Basic_3536x2140.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json"
++[mode.2]
++xml = "IMX676_Basic_1776x1778.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json"
++[mode.3]
++xml = "IMX676_Basic_1760x1070.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json"
++
+diff --git a/units/isi/drv/imx676/Sensor1_Entry.cfg b/units/isi/drv/imx676/Sensor1_Entry.cfg
+new file mode 100644
+index 0000000..9fa8f83
+--- /dev/null
++++ b/units/isi/drv/imx676/Sensor1_Entry.cfg
+@@ -0,0 +1,16 @@
++name = "imx676"
++drv = "imx676.drv"
++mode = 0
++[mode.0]
++xml = "IMX676_Basic_3536x3072.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json"
++[mode.1]
++xml = "IMX676_Basic_3536x2140.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json"
++[mode.2]
++xml = "IMX676_Basic_1776x1778.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_1760x1778.json"
++[mode.3]
++xml = "IMX676_Basic_1760x1070.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json"
++
+diff --git a/units/isi/drv/imx676/calib/CMakeLists.txt b/units/isi/drv/imx676/calib/CMakeLists.txt
+new file mode 100644
+index 0000000..9944bca
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/CMakeLists.txt
+@@ -0,0 +1,44 @@
++cmake_minimum_required(VERSION 2.6)
++
++# use upper level module name
++
++# get calib data filenames
++file(GLOB_RECURSE calib_files *.xml)
++list(SORT calib_files)
++
++# a nice helper function
++function(add_calib_target ${calib_file})
++    # get calib data file's base name
++    get_filename_component(base_name ${calib_file} NAME_WE)
++
++    # add target to put sensor driver calibration data file into the 'bin' output and create a similar named symlink to the driver as well
++    add_custom_target(${base_name}_calib
++                      ALL
++                      COMMAND ${CMAKE_COMMAND} -E copy ${calib_file} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.xml
++                      #COMMAND ${CMAKE_COMMAND} -E create_symlink ${module}.drv ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.drv
++                      DEPENDS ${calib_file}
++                      COMMENT "Configuring ${base_name} calibration database"
++                      )
++
++#    add_dependencies(${module}_static
++#                     ${base_name}_calib
++#                     )
++
++    add_dependencies(${module}_shared
++                     ${base_name}_calib
++                     )
++
++    # install the sensor driver config & similar named driver symlink as well, but to 'bin' location!
++    install(FILES       ${calib_file}
++            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++            RENAME      ${base_name}.xml
++            )
++    install(CODE "${CMAKE_COMMAND} -E create_symlink ${module}.drv ${CMAKE_INSTALL_PREFIX}/bin/${base_name}.drv")
++endfunction(add_calib_target)
++
++# loop over all calib data files
++foreach(calib_file ${calib_files})
++    add_calib_target(calib_file)
++endforeach(calib_file)
++
++
+diff --git a/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1760x1070.xml b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1760x1070.xml
+new file mode 100644
+index 0000000..33547fb
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1760x1070.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX676
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 47]">
++         Basic_1760x1070
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1760]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 1070]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  1760x1070
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  1760x1070
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.385336 0.429556 0.18511]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.71194 0.0097675 0.702172 0.39976 -0.816438 0.41668]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.820917 -0.571048 -2.554]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.013819 0.00722114 0.0011897 -0.00399385 -0.00833074 -0.011908 -0.0146032 -0.016352 -0.0171647 -0.0169741 -0.0156926 -0.0132803 -0.00972973 -0.00487877 0.00123884 0.010934]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.00381903 0.00277886 0.0088103 0.0139938 0.0183307 0.021908 0.0246032 0.026352 0.0271647 0.0269741 0.0256926 0.0232803 0.0197297 0.0148788 0.00876116 -0.00093391]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.21686 0.194643 0.174241 0.155147 0.138037 0.12253 0.109015 0.0975558 0.0887584 0.0823533 0.0786269 0.0779057 0.0804235 0.0865994 0.0966112 0.11696]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [-0.0168599 0.00535737 0.0257592 0.0448526 0.0619626 0.07747 0.090985 0.102444 0.111242 0.117647 0.121373 0.122094 0.119576 0.113401 0.103389 0.083043]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.3171]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 2.0477]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 2.0877]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.7554]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [8617.92 10262.6 10262.6 16308.0457]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 944.5374]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0244719 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1760x1070
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1760x1070_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.33093 1 1 2.5447]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-89.6314 -107.172 -129.623]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_102
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [579.99 513.212 513.212 3466.5393]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 210.372]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.202144 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1760x1070
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1760x1070_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [2.08721 1 1 1.5219]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-93.2398 -100.957 -102.7025]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [871.154 668.311 668.311 2999.7143]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 234.2648]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0753561 -0.054763]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1760x1070
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1760x1070_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.5192 1 1 2.2116]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-91.4644 -105.469 -92.3084]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1760x1070_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [90 104 109 113 115 116 118 119]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [62 65 68 68 70 68 70 69]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1760x1070_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [90 104 109 113 115 116 118 119]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [62 65 68 68 70 68 70 69]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1760x1070_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [90 104 109 113 115 116 118 119]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [62 65 68 68 70 68 70 69]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1760x1070_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [90 104 109 113 115 116 118 119]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [62 65 68 68 70 68 70 69]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_102
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 102]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-89.6314 -107.172 -129.623]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.33093 1 1 2.5447]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-93.2398 -100.957 -102.7025]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [2.08721 1 1 1.5219]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-91.4644 -105.469 -92.3084]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.5192 1 1 2.2116]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.48653 -1.45883 0.0142414 -0.744926 2.08514 -0.294523 -0.0837757 -1.02133 2.1284]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-85.2607 -107.939 -95.5088]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.70434 1 1 2.2565]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1760x1070_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1760x1070_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1760x1070_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1776x1778.xml b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1776x1778.xml
+new file mode 100644
+index 0000000..803de16
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1776x1778.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX676
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 47]">
++         Basic_1776x1778
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1776]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 1778]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  1776x1778
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  1776x1778
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.385336 0.429556 0.18511]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.71194 0.0097675 0.702172 0.39976 -0.816438 0.41668]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.820917 -0.571048 -2.554]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.013819 0.00722114 0.0011897 -0.00399385 -0.00833074 -0.011908 -0.0146032 -0.016352 -0.0171647 -0.0169741 -0.0156926 -0.0132803 -0.00972973 -0.00487877 0.00123884 0.010934]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.00381903 0.00277886 0.0088103 0.0139938 0.0183307 0.021908 0.0246032 0.026352 0.0271647 0.0269741 0.0256926 0.0232803 0.0197297 0.0148788 0.00876116 -0.00093391]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.21686 0.194643 0.174241 0.155147 0.138037 0.12253 0.109015 0.0975558 0.0887584 0.0823533 0.0786269 0.0779057 0.0804235 0.0865994 0.0966112 0.11696]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [-0.0168599 0.00535737 0.0257592 0.0448526 0.0619626 0.07747 0.090985 0.102444 0.111242 0.117647 0.121373 0.122094 0.119576 0.113401 0.103389 0.083043]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.3171]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 2.0477]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 2.0877]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.7554]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [8617.92 10262.6 10262.6 16308.0457]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 944.5374]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0244719 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1776x1778
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1776x1778_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.33093 1 1 2.5447]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-89.6314 -107.172 -129.623]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_102
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [579.99 513.212 513.212 3466.5393]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 210.372]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.202144 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1776x1778
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1776x1778_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [2.08721 1 1 1.5219]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-93.2398 -100.957 -102.7025]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [871.154 668.311 668.311 2999.7143]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 234.2648]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0753561 -0.054763]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1776x1778
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1776x1778_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.5192 1 1 2.2116]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-91.4644 -105.469 -92.3084]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1776x1778_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [82 100 107 114 118 122 123 122]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [82 98 108 115 120 121 122 123]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1776x1778_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [82 100 107 114 118 122 123 122]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [82 98 108 115 120 121 122 123]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1776x1778_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [82 100 107 114 118 122 123 122]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [82 98 108 115 120 121 122 123]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1776x1778_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [82 100 107 114 118 122 123 122]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [82 98 108 115 120 121 122 123]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_102
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 102]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-89.6314 -107.172 -129.623]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.33093 1 1 2.5447]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-93.2398 -100.957 -102.7025]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [2.08721 1 1 1.5219]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-91.4644 -105.469 -92.3084]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.5192 1 1 2.2116]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.48653 -1.45883 0.0142414 -0.744926 2.08514 -0.294523 -0.0837757 -1.02133 2.1284]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-85.2607 -107.939 -95.5088]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.70434 1 1 2.2565]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1776x1778_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1776x1778_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1776x1778_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x2140.xml b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x2140.xml
+new file mode 100644
+index 0000000..6dfac05
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x2140.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX676
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 47]">
++         Basic_3536x2140
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 3536]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 2140]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  3536x2140
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  3536x2140
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.385336 0.429556 0.18511]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.71194 0.0097675 0.702172 0.39976 -0.816438 0.41668]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.820917 -0.571048 -2.554]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.013819 0.00722114 0.0011897 -0.00399385 -0.00833074 -0.011908 -0.0146032 -0.016352 -0.0171647 -0.0169741 -0.0156926 -0.0132803 -0.00972973 -0.00487877 0.00123884 0.010934]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.00381903 0.00277886 0.0088103 0.0139938 0.0183307 0.021908 0.0246032 0.026352 0.0271647 0.0269741 0.0256926 0.0232803 0.0197297 0.0148788 0.00876116 -0.00093391]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.21686 0.194643 0.174241 0.155147 0.138037 0.12253 0.109015 0.0975558 0.0887584 0.0823533 0.0786269 0.0779057 0.0804235 0.0865994 0.0966112 0.11696]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [-0.0168599 0.00535737 0.0257592 0.0448526 0.0619626 0.07747 0.090985 0.102444 0.111242 0.117647 0.121373 0.122094 0.119576 0.113401 0.103389 0.083043]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.3171]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 2.0477]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 2.0877]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.7554]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [8617.92 10262.6 10262.6 16308.0457]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 944.5374]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0244719 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x2140
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        3536x2140_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.33093 1 1 2.5447]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-89.6314 -107.172 -129.623]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_102
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [579.99 513.212 513.212 3466.5393]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 210.372]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.202144 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x2140
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3536x2140_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [2.08721 1 1 1.5219]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-93.2398 -100.957 -102.7025]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [871.154 668.311 668.311 2999.7143]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 234.2648]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0753561 -0.054763]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x2140
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3536x2140_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.5192 1 1 2.2116]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-91.4644 -105.469 -92.3084]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3536x2140_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [198 210 216 223 227 230 236 236]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [129 132 133 136 135 138 138 139]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3536x2140_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [198 210 216 223 227 230 236 236]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [129 132 133 136 135 138 138 139]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3536x2140_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [198 210 216 223 227 230 236 236]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [129 132 133 136 135 138 138 139]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3536x2140_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [198 210 216 223 227 230 236 236]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [129 132 133 136 135 138 138 139]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_102
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 102]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-89.6314 -107.172 -129.623]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.33093 1 1 2.5447]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-93.2398 -100.957 -102.7025]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [2.08721 1 1 1.5219]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-91.4644 -105.469 -92.3084]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.5192 1 1 2.2116]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.48653 -1.45883 0.0142414 -0.744926 2.08514 -0.294523 -0.0837757 -1.02133 2.1284]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-85.2607 -107.939 -95.5088]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.70434 1 1 2.2565]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x2140_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x2140_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x2140_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [50 50 50 50]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x3072.xml b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x3072.xml
+new file mode 100644
+index 0000000..b5c2e65
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x3072.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX676
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 47]">
++         Basic_3536x3072
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 3536]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 3072]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  3536x3072
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  3536x3072
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.385336 0.429556 0.18511]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.71194 0.0097675 0.702172 0.39976 -0.816438 0.41668]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.820917 -0.571048 -2.554]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.013819 0.00722114 0.0011897 -0.00399385 -0.00833074 -0.011908 -0.0146032 -0.016352 -0.0171647 -0.0169741 -0.0156926 -0.0132803 -0.00972973 -0.00487877 0.00123884 0.010934]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.00381903 0.00277886 0.0088103 0.0139938 0.0183307 0.021908 0.0246032 0.026352 0.0271647 0.0269741 0.0256926 0.0232803 0.0197297 0.0148788 0.00876116 -0.00093391]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.21686 0.194643 0.174241 0.155147 0.138037 0.12253 0.109015 0.0975558 0.0887584 0.0823533 0.0786269 0.0779057 0.0804235 0.0865994 0.0966112 0.11696]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [-0.0168599 0.00535737 0.0257592 0.0448526 0.0619626 0.07747 0.090985 0.102444 0.111242 0.117647 0.121373 0.122094 0.119576 0.113401 0.103389 0.083043]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.3171]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 2.0477]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 2.0877]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.7554]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [8617.92 10262.6 10262.6 16308.0457]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 944.5374]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0244719 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x3072
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        3536x3072_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.33093 1 1 2.5447]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-89.6314 -107.172 -129.623]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_102
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [579.99 513.212 513.212 3466.5393]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 210.372]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.202144 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x3072
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3536x3072_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [2.08721 1 1 1.5219]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-93.2398 -100.957 -102.7025]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [871.154 668.311 668.311 2999.7143]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 234.2648]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0753561 -0.054763]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x3072
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3536x3072_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.5192 1 1 2.2116]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-91.4644 -105.469 -92.3084]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3536x3072_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [192 206 215 224 229 233 238 239]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [172 182 190 194 198 200 205 205]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3536x3072_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [192 206 215 224 229 233 238 239]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [172 182 190 194 198 200 205 205]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3536x3072_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [192 206 215 224 229 233 238 239]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [172 182 190 194 198 200 205 205]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3536x3072_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [192 206 215 224 229 233 238 239]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [172 182 190 194 198 200 205 205]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_102
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 102]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-89.6314 -107.172 -129.623]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.33093 1 1 2.5447]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-93.2398 -100.957 -102.7025]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [2.08721 1 1 1.5219]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-91.4644 -105.469 -92.3084]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.5192 1 1 2.2116]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.48653 -1.45883 0.0142414 -0.744926 2.08514 -0.294523 -0.0837757 -1.02133 2.1284]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-85.2607 -107.939 -95.5088]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.70434 1 1 2.2565]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x3072_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x3072_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x3072_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [50 50 50 50]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx676/source/IMX676.c b/units/isi/drv/imx676/source/IMX676.c
+new file mode 100644
+index 0000000..47964bc
+--- /dev/null
++++ b/units/isi/drv/imx676/source/IMX676.c
+@@ -0,0 +1,1268 @@
++/******************************************************************************\
++|* Copyright (c) 2020 by VeriSilicon Holdings Co., Ltd. ("VeriSilicon")       *|
++|* All Rights Reserved.                                                       *|
++|*                                                                            *|
++|* The material in this file is confidential and contains trade secrets of    *|
++|* of VeriSilicon.  This is proprietary information owned or licensed by      *|
++|* VeriSilicon.  No part of this work may be disclosed, reproduced, copied,   *|
++|* transmitted, or used in any way for any purpose, without the express       *|
++|* written permission of VeriSilicon.                                         *|
++|*                                                                            *|
++\******************************************************************************/
++
++#include <ebase/types.h>
++#include <ebase/trace.h>
++#include <ebase/builtins.h>
++#include <common/return_codes.h>
++#include <common/misc.h>
++#include <sys/ioctl.h>
++#include <fcntl.h>
++#include "isi.h"
++#include "isi_iss.h"
++#include "isi_priv.h"
++#include "vvsensor.h"
++
++CREATE_TRACER( IMX676_INFO , "IMX676: ", INFO,    1);
++CREATE_TRACER( IMX676_WARN , "IMX676: ", WARNING, 1);
++CREATE_TRACER( IMX676_ERROR, "IMX676: ", ERROR,   1);
++
++#ifdef SUBDEV_V4L2
++#include <sys/ioctl.h>
++#include <sys/mman.h>
++#include <fcntl.h>
++#include <linux/videodev2.h>
++#include <linux/v4l2-subdev.h>
++//#undef TRACE
++//#define TRACE(x, ...)
++#endif
++
++static const char SensorName[16] = "imx676";
++
++typedef struct IMX676_Context_s
++{
++    IsiSensorContext_t  IsiCtx;
++    struct vvcam_mode_info_s CurMode;
++    IsiSensorAeInfo_t AeInfo;
++    IsiSensorIntTime_t IntTime;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    IsiSensorGain_t SensorGain;
++    uint32_t minAfps;
++    uint64_t AEStartExposure;
++} IMX676_Context_t;
++
++static RESULT IMX676_IsiSensorSetPowerIss(IsiSensorHandle_t handle, bool_t on)
++{
++    int ret = 0;
++
++    TRACE( IMX676_INFO, "%s: (enter)\n", __func__);
++    TRACE( IMX676_INFO, "%s: set power %d\n", __func__,on);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    int32_t power = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_POWER, &power);
++    if (ret != 0){
++        TRACE(IMX676_ERROR, "%s set power %d error\n", __func__,power);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorGetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (!pclk)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CLK, pclk);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s get clock error\n", __func__);
++        return RET_FAILURE;
++    } 
++    
++    TRACE( IMX676_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++    TRACE( IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorSetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pclk == NULL)
++        return RET_NULL_POINTER;
++    
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_CLK, &pclk);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX676_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++
++    TRACE( IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiResetSensorIss(IsiSensorHandle_t handle)
++{
++    int ret = 0;
++
++    TRACE( IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_RESET, NULL);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s set reset error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiRegisterReadIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        uint32_t * pValue)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_READ_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: read sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    *pValue = sccb_data.data;
++
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiRegisterWriteIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        const uint32_t value)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = value;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_WRITE_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: write sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_UpdateIsiAEInfo(IsiSensorHandle_t handle)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    IsiSensorAeInfo_t *pAeInfo = &pIMX676Ctx->AeInfo;
++    pAeInfo->oneLineExpTime = pIMX676Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++
++    if (pIMX676Ctx->CurMode.hdr_mode == SENSOR_MODE_LINEAR) {
++        pAeInfo->maxIntTime.linearInt =
++            pIMX676Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->minIntTime.linearInt =
++            pIMX676Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->maxAGain.linearGainParas = pIMX676Ctx->CurMode.ae_info.max_again;
++        pAeInfo->minAGain.linearGainParas = pIMX676Ctx->CurMode.ae_info.min_again;
++        pAeInfo->maxDGain.linearGainParas = pIMX676Ctx->CurMode.ae_info.max_dgain;
++        pAeInfo->minDGain.linearGainParas = pIMX676Ctx->CurMode.ae_info.min_dgain;
++    } else {
++        switch (pIMX676Ctx->CurMode.stitching_mode) {
++            case SENSOR_STITCHING_DUAL_DCG:
++            case SENSOR_STITCHING_3DOL:
++            case SENSOR_STITCHING_LINEBYLINE:
++                pAeInfo->maxIntTime.triInt.triSIntTime =
++                    pIMX676Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triSIntTime =
++                    pIMX676Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                
++                pAeInfo->maxIntTime.triInt.triIntTime =
++                    pIMX676Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triIntTime =
++                    pIMX676Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX676Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG) {
++                    pAeInfo->maxIntTime.triInt.triLIntTime = pAeInfo->maxIntTime.triInt.triIntTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime = pAeInfo->minIntTime.triInt.triIntTime;
++                } else {
++                    pAeInfo->maxIntTime.triInt.triLIntTime =
++                        pIMX676Ctx->CurMode.ae_info.max_longintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime =
++                        pIMX676Ctx->CurMode.ae_info.min_longintegration_line * pAeInfo->oneLineExpTime;
++                }
++
++                pAeInfo->maxAGain.triGainParas.triSGain = pIMX676Ctx->CurMode.ae_info.max_short_again;
++                pAeInfo->minAGain.triGainParas.triSGain = pIMX676Ctx->CurMode.ae_info.min_short_again;
++                pAeInfo->maxDGain.triGainParas.triSGain = pIMX676Ctx->CurMode.ae_info.max_short_dgain;
++                pAeInfo->minDGain.triGainParas.triSGain = pIMX676Ctx->CurMode.ae_info.min_short_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triGain = pIMX676Ctx->CurMode.ae_info.max_again;
++                pAeInfo->minAGain.triGainParas.triGain = pIMX676Ctx->CurMode.ae_info.min_again;
++                pAeInfo->maxDGain.triGainParas.triGain = pIMX676Ctx->CurMode.ae_info.max_dgain;
++                pAeInfo->minDGain.triGainParas.triGain = pIMX676Ctx->CurMode.ae_info.min_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triLGain = pIMX676Ctx->CurMode.ae_info.max_long_again;
++                pAeInfo->minAGain.triGainParas.triLGain = pIMX676Ctx->CurMode.ae_info.min_long_again;
++                pAeInfo->maxDGain.triGainParas.triLGain = pIMX676Ctx->CurMode.ae_info.max_long_dgain;
++                pAeInfo->minDGain.triGainParas.triLGain = pIMX676Ctx->CurMode.ae_info.min_long_dgain;
++                break;
++            case SENSOR_STITCHING_DUAL_DCG_NOWAIT:
++            case SENSOR_STITCHING_16BIT_COMPRESS:
++            case SENSOR_STITCHING_L_AND_S:
++            case SENSOR_STITCHING_2DOL:
++                pAeInfo->maxIntTime.dualInt.dualIntTime =
++                    pIMX676Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.dualInt.dualIntTime =
++                    pIMX676Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX676Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime = pAeInfo->maxIntTime.dualInt.dualIntTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime = pAeInfo->minIntTime.dualInt.dualIntTime;
++                } else {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime =
++                        pIMX676Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime =
++                        pIMX676Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                }
++                
++                if (pIMX676Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.min_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.max_long_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.min_long_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.max_long_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.min_long_dgain;
++                } else {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.max_short_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.min_short_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.max_short_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.min_short_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.min_dgain;
++                }
++                
++                break;
++            default:
++                break;
++        }
++    }
++    pAeInfo->gainStep = pIMX676Ctx->CurMode.ae_info.gain_step;
++    pAeInfo->currFps  = pIMX676Ctx->CurMode.ae_info.cur_fps;
++    pAeInfo->maxFps   = pIMX676Ctx->CurMode.ae_info.max_fps;
++    pAeInfo->minFps   = pIMX676Ctx->CurMode.ae_info.min_fps;
++    pAeInfo->minAfps  = pIMX676Ctx->CurMode.ae_info.min_afps;
++    pAeInfo->hdrRatio[0] = pIMX676Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s;
++    pAeInfo->hdrRatio[1] = pIMX676Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs;
++
++    pAeInfo->intUpdateDlyFrm = pIMX676Ctx->CurMode.ae_info.int_update_delay_frm;
++    pAeInfo->gainUpdateDlyFrm = pIMX676Ctx->CurMode.ae_info.gain_update_delay_frm;
++
++    if (pIMX676Ctx->minAfps != 0) {
++        pAeInfo->minAfps = pIMX676Ctx->minAfps;
++    } 
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    memcpy(pMode, &pIMX676Ctx->CurMode, sizeof(IsiSensorMode_t));
++
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    struct vvcam_mode_info_s sensor_mode;
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    sensor_mode.index = pMode->index;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s set sensor mode failed", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX676Ctx->CurMode, &sensor_mode, sizeof(struct vvcam_mode_info_s));
++    IMX676_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorSetStreamingIss(IsiSensorHandle_t handle,
++                                              bool_t on)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    uint32_t status = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_STREAM, &status);
++    if (ret != 0){
++        TRACE(IMX676_ERROR, "%s set sensor stream %d error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: set streaming %d\n", __func__, on);
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiCreateSensorIss(IsiSensorInstanceConfig_t * pConfig)
++{
++    RESULT result = RET_SUCCESS;
++    IMX676_Context_t *pIMX676Ctx;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    if (!pConfig || !pConfig->pSensor || !pConfig->HalHandle)
++        return RET_NULL_POINTER;
++
++    pIMX676Ctx = (IMX676_Context_t *) malloc(sizeof(IMX676_Context_t));
++    if (!pIMX676Ctx)
++        return RET_OUTOFMEM;
++
++    memset(pIMX676Ctx, 0, sizeof(IMX676_Context_t));
++    pIMX676Ctx->IsiCtx.HalHandle = pConfig->HalHandle;
++    pIMX676Ctx->IsiCtx.pSensor   = pConfig->pSensor;
++    pConfig->hSensor = (IsiSensorHandle_t) pIMX676Ctx;
++
++    result = IMX676_IsiSensorSetPowerIss(pIMX676Ctx, BOOL_TRUE);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s set power error\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    result = IMX676_IsiSensorGetClkIss(pIMX676Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s get clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    clk.status = 1;
++    result = IMX676_IsiSensorSetClkIss(pIMX676Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    result = IMX676_IsiResetSensorIss(pIMX676Ctx);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s retset sensor error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    IsiSensorMode_t SensorMode;
++    SensorMode.index = pConfig->SensorModeIndex;
++    result = IMX676_IsiSetSensorModeIss(pIMX676Ctx, &SensorMode);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX676_IsiReleaseSensorIss(IsiSensorHandle_t handle)
++{
++    TRACE(IMX676_INFO, "%s (enter) \n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    if (pIMX676Ctx == NULL)
++        return (RET_WRONG_HANDLE);
++
++    IMX676_IsiSensorSetStreamingIss(pIMX676Ctx, BOOL_FALSE);
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    IMX676_IsiSensorGetClkIss(pIMX676Ctx, &clk);
++    clk.status = 0;
++    IMX676_IsiSensorSetClkIss(pIMX676Ctx, &clk);
++    IMX676_IsiSensorSetPowerIss(pIMX676Ctx, BOOL_FALSE);
++    free(pIMX676Ctx);
++    pIMX676Ctx = NULL;
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiHalQuerySensorIss(HalHandle_t HalHandle,
++                                          IsiSensorModeInfoArray_t *pSensorMode)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter) \n", __func__);
++
++    if (HalHandle == NULL || pSensorMode == NULL)
++        return RET_NULL_POINTER;
++
++    HalContext_t *pHalCtx = (HalContext_t *)HalHandle;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_QUERY, pSensorMode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiQuerySensorIss(IsiSensorHandle_t handle,
++                                       IsiSensorModeInfoArray_t *pSensorMode)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX676_INFO, "%s (enter) \n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    result = IMX676_IsiHalQuerySensorIss(pIMX676Ctx->IsiCtx.HalHandle,
++                                         pSensorMode);
++    if (result != RET_SUCCESS)
++        TRACE(IMX676_ERROR, "%s: query sensor mode info error!\n", __func__);
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX676_IsiGetCapsIss(IsiSensorHandle_t handle,
++                                   IsiSensorCaps_t * pIsiSensorCaps)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX676_INFO, "%s (enter) \n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    IsiSensorModeInfoArray_t SensorModeInfo;
++    memset(&SensorModeInfo, 0, sizeof(IsiSensorModeInfoArray_t));
++    result = IMX676_IsiQuerySensorIss(handle, &SensorModeInfo);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    pIsiSensorCaps->FieldSelection    = ISI_FIELDSEL_BOTH;
++    pIsiSensorCaps->YCSequence        = ISI_YCSEQ_YCBYCR;
++    pIsiSensorCaps->Conv422           = ISI_CONV422_NOCOSITED;
++    pIsiSensorCaps->HPol              = ISI_HPOL_REFPOS;
++    pIsiSensorCaps->VPol              = ISI_VPOL_NEG;
++    pIsiSensorCaps->Edge              = ISI_EDGE_RISING;
++    pIsiSensorCaps->supportModeNum    = SensorModeInfo.count;
++    pIsiSensorCaps->currentMode       = pIMX676Ctx->CurMode.index;
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX676_IsiSetupSensorIss(IsiSensorHandle_t handle,
++                                       const IsiSensorCaps_t *pIsiSensorCaps )
++{
++    int ret = 0;
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    if (pIsiSensorCaps->currentMode != pIMX676Ctx->CurMode.index) {
++        IsiSensorMode_t SensorMode;
++        memset(&SensorMode, 0, sizeof(IsiSensorMode_t));
++        SensorMode.index = pIsiSensorCaps->currentMode;
++        result = IMX676_IsiSetSensorModeIss(handle, &SensorMode);
++        if (result != RET_SUCCESS) {
++            TRACE(IMX676_ERROR, "%s:set sensor mode %d failed!\n",
++                  __func__, SensorMode.index);
++            return result;
++        }
++    }
++
++#ifdef SUBDEV_V4L2
++    struct v4l2_subdev_format format;
++    memset(&format, 0, sizeof(struct v4l2_subdev_format));
++    format.format.width  = pIMX676Ctx->CurMode.size.bounds_width;
++    format.format.height = pIMX676Ctx->CurMode.size.bounds_height;
++    format.which = V4L2_SUBDEV_FORMAT_ACTIVE;
++    format.pad = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VIDIOC_SUBDEV_S_FMT, &format);
++    if (ret != 0){
++        TRACE(IMX676_ERROR, "%s: sensor set format error!\n", __func__);
++        return RET_FAILURE;
++    }
++#else
++    ret = ioctrl(pHalCtx->sensor_fd, VVSENSORIOC_S_INIT, NULL);
++    if (ret != 0){
++        TRACE(IMX676_ERROR, "%s: sensor init error!\n", __func__);
++        return RET_FAILURE;
++    }
++#endif
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetSensorRevisionIss(IsiSensorHandle_t handle, uint32_t *pValue)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pValue == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CHIP_ID, pValue);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: get chip id error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiCheckSensorConnectionIss(IsiSensorHandle_t handle)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    uint32_t ChipId = 0;
++    result = IMX676_IsiGetSensorRevisionIss(handle, &ChipId);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s:get sensor chip id error!\n",__func__);
++        return RET_FAILURE;
++    }
++
++    if (ChipId != 676) {
++        TRACE(IMX676_ERROR,
++            "%s:ChipID=676,while read sensor Id=0x%x error!\n",
++             __func__, ChipId);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetAeInfoIss(IsiSensorHandle_t handle,
++                                     IsiSensorAeInfo_t *pAeInfo)
++{
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    if (pAeInfo == NULL)
++        return RET_NULL_POINTER;
++
++    memcpy(pAeInfo, &pIMX676Ctx->AeInfo, sizeof(IsiSensorAeInfo_t));
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetHdrRatioIss(IsiSensorHandle_t handle,
++                                       uint8_t hdrRatioNum,
++                                       uint32_t HdrRatio[])
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    struct sensor_hdr_artio_s hdr_ratio;
++    if (hdrRatioNum == 2) {
++        hdr_ratio.ratio_s_vs = HdrRatio[1];
++        hdr_ratio.ratio_l_s = HdrRatio[0];
++    }else {
++        hdr_ratio.ratio_s_vs = HdrRatio[0];
++        hdr_ratio.ratio_l_s = 0;
++    }
++
++    if (hdr_ratio.ratio_s_vs == pIMX676Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs &&
++        hdr_ratio.ratio_l_s == pIMX676Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s)
++        return RET_SUCCESS;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_HDR_RADIO, &hdr_ratio);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR,"%s: set hdr ratio error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s sensor_mode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR,"%s: get mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memcpy(&pIMX676Ctx->CurMode, &sensor_mode, sizeof (struct vvcam_mode_info_s));
++    IMX676_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    memcpy(pIntegrationTime, &pIMX676Ctx->IntTime, sizeof(IsiSensorIntTime_t));
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++
++}
++
++static RESULT IMX676_IsiSetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    int ret = 0;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    uint32_t oneLineTime;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++    printf("\n\nAAAAAAAAAAAAAAA %u\n\n", pIntegrationTime->IntegrationTime.linearInt);
++    if (pIntegrationTime == NULL)
++        return RET_NULL_POINTER;
++
++    oneLineTime =  pIMX676Ctx->AeInfo.oneLineExpTime;
++    pIMX676Ctx->IntTime.expoFrmType = pIntegrationTime->expoFrmType;
++
++    switch (pIntegrationTime->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            IntLine = pIntegrationTime->IntegrationTime.linearInt;
++            if (IntLine != pIMX676Ctx->IntLine) {
++                printf("\n\ngoing into S_EXP ioctl %u\n\n", IntLine);
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor linear exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++               pIMX676Ctx->IntLine = IntLine;
++            }
++            TRACE(IMX676_INFO, "%s set linear exp %d \n", __func__,IntLine);
++            pIMX676Ctx->IntTime.IntegrationTime.linearInt =  IntLine * oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            IntLine = pIntegrationTime->IntegrationTime.dualInt.dualIntTime;
++            if (IntLine != pIMX676Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor dual exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX676Ctx->IntLine = IntLine;
++            }
++
++            if (pIMX676Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                ShortIntLine = pIntegrationTime->IntegrationTime.dualInt.dualSIntTime;
++                if (ShortIntLine != pIMX676Ctx->ShortIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX676_ERROR,"%s:set sensor dual vsexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX676Ctx->ShortIntLine = ShortIntLine;
++                }
++            } else {
++                ShortIntLine = IntLine;
++                pIMX676Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX676_INFO, "%s set dual exp %d short_exp %d\n", __func__, IntLine, ShortIntLine);
++            pIMX676Ctx->IntTime.IntegrationTime.dualInt.dualIntTime  = IntLine + oneLineTime;
++            pIMX676Ctx->IntTime.IntegrationTime.dualInt.dualSIntTime = ShortIntLine + oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            if (pIMX676Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triLIntTime;
++                if (LongIntLine != pIMX676Ctx->LongIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_EXP, &LongIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX676_ERROR,"%s:set sensor tri lexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX676Ctx->LongIntLine = LongIntLine;
++                }
++            } else {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++                pIMX676Ctx->LongIntLine = LongIntLine;
++            }
++
++            IntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++            if (IntLine != pIMX676Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX676Ctx->IntLine = IntLine;
++            }
++            
++            ShortIntLine = pIntegrationTime->IntegrationTime.triInt.triSIntTime;
++            if (ShortIntLine != pIMX676Ctx->ShortIntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri vsexp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX676Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX676_INFO, "%s set tri long exp %d exp %d short_exp %d\n", __func__, LongIntLine, IntLine, ShortIntLine);
++            pIMX676Ctx->IntTime.IntegrationTime.triInt.triLIntTime = LongIntLine + oneLineTime;
++            pIMX676Ctx->IntTime.IntegrationTime.triInt.triIntTime = IntLine + oneLineTime;
++            pIMX676Ctx->IntTime.IntegrationTime.triInt.triSIntTime = ShortIntLine + oneLineTime;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++    
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++    memcpy(pGain, &pIMX676Ctx->SensorGain, sizeof(IsiSensorGain_t));
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    int ret = 0;
++    uint32_t LongGain;
++    uint32_t Gain;
++    uint32_t ShortGain;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++
++    pIMX676Ctx->SensorGain.expoFrmType = pGain->expoFrmType;
++    switch (pGain->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            Gain = pGain->gain.linearGainParas;
++            if (pIMX676Ctx->SensorGain.gain.linearGainParas != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor linear gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            pIMX676Ctx->SensorGain.gain.linearGainParas = pGain->gain.linearGainParas;
++            TRACE(IMX676_INFO, "%s set linear gain %d\n", __func__,pGain->gain.linearGainParas);
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            Gain = pGain->gain.dualGainParas.dualGain;
++            if (pIMX676Ctx->SensorGain.gain.dualGainParas.dualGain != Gain) {
++                if (pIMX676Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &Gain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor dual gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.dualGainParas.dualSGain;
++            if (pIMX676Ctx->SensorGain.gain.dualGainParas.dualSGain != ShortGain) {
++                if (pIMX676Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &ShortGain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor dual vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX676_INFO,"%s:set gain%d short gain %d!\n", __func__,Gain,ShortGain);
++            pIMX676Ctx->SensorGain.gain.dualGainParas.dualGain = Gain;
++            pIMX676Ctx->SensorGain.gain.dualGainParas.dualSGain = ShortGain;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            LongGain = pGain->gain.triGainParas.triLGain;
++            if (pIMX676Ctx->SensorGain.gain.triGainParas.triLGain != LongGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &LongGain);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            Gain = pGain->gain.triGainParas.triGain;
++            if (pIMX676Ctx->SensorGain.gain.triGainParas.triGain != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.triGainParas.triSGain;
++            if (pIMX676Ctx->SensorGain.gain.triGainParas.triSGain != ShortGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX676_INFO,"%s:set long gain %d gain%d short gain %d!\n", __func__, LongGain, Gain, ShortGain);
++            pIMX676Ctx->SensorGain.gain.triGainParas.triLGain = LongGain;
++            pIMX676Ctx->SensorGain.gain.triGainParas.triGain = Gain;
++            pIMX676Ctx->SensorGain.gain.triGainParas.triSGain = ShortGain;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++
++static RESULT IMX676_IsiGetSensorFpsIss(IsiSensorHandle_t handle, uint32_t * pfps)
++{
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    if (pfps == NULL)
++        return RET_NULL_POINTER;
++
++    *pfps = pIMX676Ctx->CurMode.ae_info.cur_fps;
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetSensorFpsIss(IsiSensorHandle_t handle, uint32_t fps)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_FPS, &fps);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR,"%s:set sensor fps error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s SensorMode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &SensorMode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR,"%s:get sensor mode error!\n", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX676Ctx->CurMode, &SensorMode, sizeof(struct vvcam_mode_info_s));
++    IMX676_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++static RESULT IMX676_IsiSetSensorAfpsLimitsIss(IsiSensorHandle_t handle, uint32_t minAfps)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    if ((minAfps > pIMX676Ctx->CurMode.ae_info.max_fps) ||
++        (minAfps < pIMX676Ctx->CurMode.ae_info.min_fps))
++        return RET_FAILURE;
++    pIMX676Ctx->minAfps = minAfps;
++    pIMX676Ctx->CurMode.ae_info.min_afps = minAfps;
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetSensorIspStatusIss(IsiSensorHandle_t handle,
++                               IsiSensorIspStatus_t *pSensorIspStatus)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    if (pIMX676Ctx->CurMode.hdr_mode == SENSOR_MODE_HDR_NATIVE) {
++        pSensorIspStatus->useSensorAWB = true;
++        pSensorIspStatus->useSensorBLC = true;
++    } else {
++        pSensorIspStatus->useSensorAWB = false;
++        pSensorIspStatus->useSensorBLC = false;
++    }
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++#ifndef ISI_LITE
++static RESULT IMX676_IsiSensorSetBlcIss(IsiSensorHandle_t handle, IsiSensorBlc_t * pBlc)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pBlc == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_blc_s SensorBlc;
++    SensorBlc.red = pBlc->red;
++    SensorBlc.gb = pBlc->gb;
++    SensorBlc.gr = pBlc->gr;
++    SensorBlc.blue = pBlc->blue;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_BLC, &SensorBlc);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorSetWBIss(IsiSensorHandle_t handle, IsiSensorWB_t *pWb)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pWb == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_white_balance_s SensorWb;
++    SensorWb.r_gain = pWb->r_gain;
++    SensorWb.gr_gain = pWb->gr_gain;
++    SensorWb.gb_gain = pWb->gb_gain;
++    SensorWb.b_gain = pWb->b_gain;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_WB, &SensorWb);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorGetExpandCurveIss(IsiSensorHandle_t handle, IsiSensorExpandCurve_t *pExpandCurve)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pExpandCurve == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_EXPAND_CURVE, pExpandCurve);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: get  expand cure error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetTestPatternIss(IsiSensorHandle_t handle,
++                                       IsiSensorTpgMode_e  tpgMode)
++{
++    int32_t ret = 0;
++
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    struct sensor_test_pattern_s TestPattern;
++    if (tpgMode == ISI_TPG_DISABLE) {
++        TestPattern.enable = 0;
++        TestPattern.pattern = 0;
++    } else {
++        TestPattern.enable = 1;
++        TestPattern.pattern = (uint32_t)tpgMode - 1;
++    }
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_TEST_PATTERN, &TestPattern);
++    if (ret != 0)
++    {
++        TRACE(IMX676_ERROR, "%s: set test pattern %d error\n", __func__, tpgMode);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: test pattern enable[%d] mode[%d]\n", __func__, TestPattern.enable, TestPattern.pattern);
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiFocusSetupIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiFocusReleaseIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiFocusGetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiFocusSetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetFocusCalibrateIss(IsiSensorHandle_t handle, IsiFoucsCalibAttr_t *pFocusCalib)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t *pExposure)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    if (pIMX676Ctx->AEStartExposure == 0) {
++        pIMX676Ctx->AEStartExposure =
++            (uint64_t)pIMX676Ctx->CurMode.ae_info.start_exposure *
++            pIMX676Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++           
++    }
++    *pExposure =  pIMX676Ctx->AEStartExposure;
++    TRACE(IMX676_INFO, "%s:get start exposure %d\n", __func__, pIMX676Ctx->AEStartExposure);
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t exposure)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    pIMX676Ctx->AEStartExposure = exposure;
++    TRACE(IMX676_INFO, "set start exposure %d\n", __func__,pIMX676Ctx->AEStartExposure);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++#endif
++
++RESULT IMX676_IsiGetSensorIss(IsiSensor_t *pIsiSensor)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++
++    if (pIsiSensor == NULL)
++        return RET_NULL_POINTER;
++     pIsiSensor->pszName                         = SensorName;
++     pIsiSensor->pIsiSensorSetPowerIss           = IMX676_IsiSensorSetPowerIss;
++     pIsiSensor->pIsiCreateSensorIss             = IMX676_IsiCreateSensorIss;
++     pIsiSensor->pIsiReleaseSensorIss            = IMX676_IsiReleaseSensorIss;
++     pIsiSensor->pIsiRegisterReadIss             = IMX676_IsiRegisterReadIss;
++     pIsiSensor->pIsiRegisterWriteIss            = IMX676_IsiRegisterWriteIss;
++     pIsiSensor->pIsiGetSensorModeIss            = IMX676_IsiGetSensorModeIss;
++     pIsiSensor->pIsiSetSensorModeIss            = IMX676_IsiSetSensorModeIss;
++     pIsiSensor->pIsiQuerySensorIss              = IMX676_IsiQuerySensorIss;
++     pIsiSensor->pIsiGetCapsIss                  = IMX676_IsiGetCapsIss;
++     pIsiSensor->pIsiSetupSensorIss              = IMX676_IsiSetupSensorIss;
++     pIsiSensor->pIsiGetSensorRevisionIss        = IMX676_IsiGetSensorRevisionIss;
++     pIsiSensor->pIsiCheckSensorConnectionIss    = IMX676_IsiCheckSensorConnectionIss;
++     pIsiSensor->pIsiSensorSetStreamingIss       = IMX676_IsiSensorSetStreamingIss;
++     pIsiSensor->pIsiGetAeInfoIss                = IMX676_IsiGetAeInfoIss;
++     pIsiSensor->pIsiSetHdrRatioIss              = IMX676_IsiSetHdrRatioIss;
++     pIsiSensor->pIsiGetIntegrationTimeIss       = IMX676_IsiGetIntegrationTimeIss;
++     pIsiSensor->pIsiSetIntegrationTimeIss       = IMX676_IsiSetIntegrationTimeIss;
++     pIsiSensor->pIsiGetGainIss                  = IMX676_IsiGetGainIss;
++     pIsiSensor->pIsiSetGainIss                  = IMX676_IsiSetGainIss;
++     pIsiSensor->pIsiGetSensorFpsIss             = IMX676_IsiGetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorFpsIss             = IMX676_IsiSetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorAfpsLimitsIss      = IMX676_IsiSetSensorAfpsLimitsIss;
++     pIsiSensor->pIsiGetSensorIspStatusIss       = IMX676_IsiGetSensorIspStatusIss;
++#ifndef ISI_LITE
++    pIsiSensor->pIsiSensorSetBlcIss              = IMX676_IsiSensorSetBlcIss;
++    pIsiSensor->pIsiSensorSetWBIss               = IMX676_IsiSensorSetWBIss;
++    pIsiSensor->pIsiSensorGetExpandCurveIss      = IMX676_IsiSensorGetExpandCurveIss;
++    pIsiSensor->pIsiActivateTestPatternIss       = IMX676_IsiSetTestPatternIss;
++    pIsiSensor->pIsiFocusSetupIss                = IMX676_IsiFocusSetupIss;
++    pIsiSensor->pIsiFocusReleaseIss              = IMX676_IsiFocusReleaseIss;
++    pIsiSensor->pIsiFocusSetIss                  = IMX676_IsiFocusSetIss;
++    pIsiSensor->pIsiFocusGetIss                  = IMX676_IsiFocusGetIss;
++    pIsiSensor->pIsiGetFocusCalibrateIss         = IMX676_IsiGetFocusCalibrateIss;
++    pIsiSensor->pIsiSetAeStartExposureIss        = IMX676_IsiSetAeStartExposureIs;
++    pIsiSensor->pIsiGetAeStartExposureIss        = IMX676_IsiGetAeStartExposureIs;
++#endif
++    TRACE( IMX676_INFO, "%s (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++/*****************************************************************************
++* each sensor driver need declare this struct for isi load
++*****************************************************************************/
++IsiCamDrvConfig_t IsiCamDrvConfig = {
++    .CameraDriverID = 0x0676,
++    .pIsiHalQuerySensor = IMX676_IsiHalQuerySensorIss,
++    .pfIsiGetSensorIss = IMX676_IsiGetSensorIss,
++};
+diff --git a/units/isi/drv/imx678/CMakeLists.txt b/units/isi/drv/imx678/CMakeLists.txt
+new file mode 100755
+index 0000000..48b5f31
+--- /dev/null
++++ b/units/isi/drv/imx678/CMakeLists.txt
+@@ -0,0 +1,122 @@
++cmake_minimum_required(VERSION 2.6)
++
++# define module name & interface version
++set (module imx678)
++
++# define interface version
++set (${module}_INTERFACE_CURRENT  1)
++set (${module}_INTERFACE_REVISION 0)
++set (${module}_INTERFACE_AGE      0)
++
++# we want to compile all .c files as default
++file(GLOB libsources source/IMX678.c )
++
++# set public headers, these get installed
++file(GLOB pub_headers include/*.h)
++
++# define include paths
++include_directories(
++    include
++    include_priv
++    ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include
++    )
++
++# module specific defines
++###add_definitions(-Wno-error=unused-function)
++
++# add lib to build env
++#add_library(${module}_static STATIC ${libsources})
++add_library(${module}_shared SHARED ${libsources})
++
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES OUTPUT_NAME     ${module})
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES LINK_FLAGS      -static)
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES OUTPUT_NAME     ${module})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES LINK_FLAGS      -shared)
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES SOVERSION       ${${module}_INTERFACE_CURRENT})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES VERSION         ${${module}_INTERFACE_CURRENT}.${${module}_INTERFACE_REVISION}.${${module}_INTERFACE_AGE})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++# add convenience target: put sensor driver into the 'bin' output dir as well
++if ( NOT ANDROID )
++add_custom_target(${module}.drv
++                  ALL
++                  COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${module}.drv
++                  DEPENDS ${module}_shared
++                  COMMENT "Copying ${module} driver module"
++                  )
++endif()
++
++# define lib dependencies
++#target_link_libraries(${module}_static
++#                      ${platform_libs}
++#                      ${base_libs}
++#                      ${drv_libs}
++#                      isi_shared
++#                      )
++
++# add link libs, or dlopen failed on Android
++if (ANDROID)
++if (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${platform_libs}
++                      ${base_libs}
++                      ${drv_libs}
++                      isi_shared
++                      )
++else (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${android_partial_platform_libs}
++                      ${android_partial_base_libs}
++                      ${android_partial_drv_libs}
++                      isi_shared
++                      )
++add_library(PrebuiltLibs SHARED IMPORTED)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libhal.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libbufferpool.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libcameric_drv.so)
++target_link_libraries(${module}_shared PRIVATE PrebuiltLibs)
++endif (GENERATE_PARTITION_BUILD)
++endif (ANDROID)
++
++# define stuff to install
++#install(TARGETS ${module}_static
++#        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++#        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
++#        )
++
++install(TARGETS ${module}_shared
++        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        LIBRARY         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        )
++
++# install the sensor driver as well, but to 'bin' location!
++install(FILES       ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT}
++        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++        RENAME      ${module}.drv
++        )
++
++if( DEFINED APPSHELL_TOP_COMPILE)
++add_custom_target(copy_shell_libs_${module} ALL
++       COMMENT "##Copy libs to shell libs"
++       COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so ${CMAKE_HOME_DIRECTORY}/shell_libs/ispcore/${PLATFORM}/lib${module}.so
++       #COMMAND ${CMAKE_COMMAND} -E copy_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/${module} ${CMAKE_HOME_DIRECTORY}/shell_libs/include/units_headers/${module}
++)
++add_dependencies(copy_shell_libs_${module} ${module}_shared)
++endif( DEFINED APPSHELL_TOP_COMPILE)
++
++if (NOT GENERATE_PARTITION_BUILD)
++add_custom_target(${module}_create_isi_dir
++                  COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/isi
++                  COMMENT "Create isi dir for ${module}")
++add_dependencies(${module}_create_isi_dir ${module}_shared)
++endif (NOT GENERATE_PARTITION_BUILD)
++
++unset(HEADER_CP_VAR)
++# create common targets for this module
++include(${UNITS_TOP_DIRECTORY}/targets.cmake)
++
++# create calib data targets
++add_subdirectory(calib)
+\ No newline at end of file
+diff --git a/units/isi/drv/imx678/Sensor0_Entry.cfg b/units/isi/drv/imx678/Sensor0_Entry.cfg
+new file mode 100644
+index 0000000..30811e6
+--- /dev/null
++++ b/units/isi/drv/imx678/Sensor0_Entry.cfg
+@@ -0,0 +1,10 @@
++name = "imx678"
++drv = "imx678.drv"
++mode = 0
++[mode.0]
++xml = "IMX678_Basic_3840x2160.xml"
++dwe = "dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json"
++[mode.1]
++xml = "IMX678_Basic_1920x1080.xml"
++dwe = "dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json"
++
+diff --git a/units/isi/drv/imx678/Sensor1_Entry.cfg b/units/isi/drv/imx678/Sensor1_Entry.cfg
+new file mode 100644
+index 0000000..1b51d7d
+--- /dev/null
++++ b/units/isi/drv/imx678/Sensor1_Entry.cfg
+@@ -0,0 +1,10 @@
++name = "imx678"
++drv = "imx678.drv"
++mode = 0
++[mode.0]
++xml = "IMX678_3840x2160.xml"
++dwe = "dewarp_config/sensor_dwe_4K_config.json"
++[mode.1]
++xml = "IMX678_1920x1080.xml"
++dwe = "dewarp_config/sensor_dwe_4K_config.json"
++
+diff --git a/units/isi/drv/imx678/calib/CMakeLists.txt b/units/isi/drv/imx678/calib/CMakeLists.txt
+new file mode 100644
+index 0000000..9944bca
+--- /dev/null
++++ b/units/isi/drv/imx678/calib/CMakeLists.txt
+@@ -0,0 +1,44 @@
++cmake_minimum_required(VERSION 2.6)
++
++# use upper level module name
++
++# get calib data filenames
++file(GLOB_RECURSE calib_files *.xml)
++list(SORT calib_files)
++
++# a nice helper function
++function(add_calib_target ${calib_file})
++    # get calib data file's base name
++    get_filename_component(base_name ${calib_file} NAME_WE)
++
++    # add target to put sensor driver calibration data file into the 'bin' output and create a similar named symlink to the driver as well
++    add_custom_target(${base_name}_calib
++                      ALL
++                      COMMAND ${CMAKE_COMMAND} -E copy ${calib_file} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.xml
++                      #COMMAND ${CMAKE_COMMAND} -E create_symlink ${module}.drv ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.drv
++                      DEPENDS ${calib_file}
++                      COMMENT "Configuring ${base_name} calibration database"
++                      )
++
++#    add_dependencies(${module}_static
++#                     ${base_name}_calib
++#                     )
++
++    add_dependencies(${module}_shared
++                     ${base_name}_calib
++                     )
++
++    # install the sensor driver config & similar named driver symlink as well, but to 'bin' location!
++    install(FILES       ${calib_file}
++            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++            RENAME      ${base_name}.xml
++            )
++    install(CODE "${CMAKE_COMMAND} -E create_symlink ${module}.drv ${CMAKE_INSTALL_PREFIX}/bin/${base_name}.drv")
++endfunction(add_calib_target)
++
++# loop over all calib data files
++foreach(calib_file ${calib_files})
++    add_calib_target(calib_file)
++endforeach(calib_file)
++
++
+diff --git a/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_1920x1080.xml b/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_1920x1080.xml
+new file mode 100644
+index 0000000..a602297
+--- /dev/null
++++ b/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_1920x1080.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX678
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 37]">
++         Basic_1920x1080
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1920]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 1080]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  1920x1080
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  1920x1080
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.350821 0.461451 0.18773]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.747621 0.0895615 0.658059 0.328222 -0.81157 0.48335]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.840503 -0.541807 -2.5476]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.20944 1.25673 1.30402 1.35132 1.39861 1.4459 1.4932 1.54049 1.58778 1.63508 1.68237 1.72966 1.77696 1.82425 1.87154 1.9188]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.01049 0.0067139 0.00344454 0.000598565 -0.0017099 -0.00358594 -0.00493888 -0.00576626 -0.0060659 -0.00582415 -0.00500751 -0.00359477 -0.00162514 0.000989081 0.00422767 0.010466]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.20944 1.25673 1.30402 1.35132 1.39861 1.4459 1.4932 1.54049 1.58778 1.63508 1.68237 1.72966 1.77696 1.82425 1.87154 1.9188]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.000490041 0.0032861 0.00655546 0.00940144 0.0117099 0.0135859 0.0149389 0.0157663 0.0160659 0.0158242 0.0150075 0.0135948 0.0116251 0.00901092 0.00577233 -0.00046563]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.877256 0.954511 1.03177 1.10902 1.18628 1.26353 1.34079 1.41805 1.4953 1.57256 1.64981 1.72707 1.80432 1.88158 1.9588]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.155026 0.143403 0.132925 0.123335 0.114897 0.107527 0.101224 0.0961947 0.09238 0.0900132 0.0889725 0.0893575 0.091282 0.0947975 0.100008 0.11196]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.877256 0.954511 1.03177 1.10902 1.18628 1.26353 1.34079 1.41805 1.4953 1.57256 1.64981 1.72707 1.80432 1.88158 1.9588]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0449741 0.0565967 0.0670752 0.0766648 0.0851034 0.0924732 0.0987762 0.103805 0.10762 0.109987 0.111027 0.110643 0.108718 0.105203 0.099992 0.088042]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.2094]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9188]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.9588]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.6351]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [2651.53 3387.15 3387.15 7258.5713]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 443.7393]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0306101 -0.0036106]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1920x1080_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.23923 1 1 2.7836]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.58915 0.0377625 -0.616429 -0.945174 2.52794 -0.537235 -0.217771 -1.76346 2.9884]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-36.4461 -38.1612 -29.3263]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_104
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [533.326 -38.9322 -38.9322 2476.1192]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 182.7902]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.145974 -0.0036106]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1920x1080_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.98523 1 1 1.6928]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.1243 -0.955239 -0.160056 -0.585798 2.27098 -0.616837 -0.0192654 -0.974804 2.036]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-36.8576 -44.6401 -45.1663]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_109
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [797.808 508.94 508.94 2977.8141]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 231.5529]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0300834 -0.019091]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1920x1080_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.48927 1 1 2.4188]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.05797 -0.842641 -0.197003 -0.842204 2.361 -0.441285 -0.076882 -1.19612 2.2813]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-32.4424 -44.2278 -33.9074]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_108
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1920x1080_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [120 120 120 120 120 120 120 120]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [67 67 67 67 68 68 68 68]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1920x1080_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [120 120 120 120 120 120 120 120]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [67 67 67 67 68 68 68 68]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1920x1080_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [120 120 120 120 120 120 120 120]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [67 67 67 67 68 68 68 68]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1920x1080_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [120 120 120 120 120 120 120 120]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [67 67 67 67 68 68 68 68]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_104
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 104]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.58915 0.0377625 -0.616429 -0.945174 2.52794 -0.537235 -0.217771 -1.76346 2.9884]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-36.4461 -38.1612 -29.3263]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.23923 1 1 2.7836]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_109
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 109]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.1243 -0.955239 -0.160056 -0.585798 2.27098 -0.616837 -0.0192654 -0.974804 2.036]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-36.8576 -44.6401 -45.1663]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.98523 1 1 1.6928]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_108
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 108]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.05797 -0.842641 -0.197003 -0.842204 2.361 -0.441285 -0.076882 -1.19612 2.2813]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-32.4424 -44.2278 -33.9074]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.48927 1 1 2.4188]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_108
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 108]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.64855 -1.46973 -0.171784 -0.746979 2.12541 -0.309928 -0.0672896 -1.22039 2.3223]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.8121 -42.8676 -35.6405]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.67897 1 1 2.4837]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_3840x2160.xml b/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_3840x2160.xml
+new file mode 100644
+index 0000000..82035bf
+--- /dev/null
++++ b/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_3840x2160.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX678
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 37]">
++         Basic_3840x2160
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 3840]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 2160]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  3840x2160
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  3840x2160
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.350821 0.461451 0.18773]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.747621 0.0895615 0.658059 0.328222 -0.81157 0.48335]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.840503 -0.541807 -2.5476]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.20944 1.25673 1.30402 1.35132 1.39861 1.4459 1.4932 1.54049 1.58778 1.63508 1.68237 1.72966 1.77696 1.82425 1.87154 1.9188]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.01049 0.0067139 0.00344454 0.000598565 -0.0017099 -0.00358594 -0.00493888 -0.00576626 -0.0060659 -0.00582415 -0.00500751 -0.00359477 -0.00162514 0.000989081 0.00422767 0.010466]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.20944 1.25673 1.30402 1.35132 1.39861 1.4459 1.4932 1.54049 1.58778 1.63508 1.68237 1.72966 1.77696 1.82425 1.87154 1.9188]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.000490041 0.0032861 0.00655546 0.00940144 0.0117099 0.0135859 0.0149389 0.0157663 0.0160659 0.0158242 0.0150075 0.0135948 0.0116251 0.00901092 0.00577233 -0.00046563]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.877256 0.954511 1.03177 1.10902 1.18628 1.26353 1.34079 1.41805 1.4953 1.57256 1.64981 1.72707 1.80432 1.88158 1.9588]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.155026 0.143403 0.132925 0.123335 0.114897 0.107527 0.101224 0.0961947 0.09238 0.0900132 0.0889725 0.0893575 0.091282 0.0947975 0.100008 0.11196]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.877256 0.954511 1.03177 1.10902 1.18628 1.26353 1.34079 1.41805 1.4953 1.57256 1.64981 1.72707 1.80432 1.88158 1.9588]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0449741 0.0565967 0.0670752 0.0766648 0.0851034 0.0924732 0.0987762 0.103805 0.10762 0.109987 0.111027 0.110643 0.108718 0.105203 0.099992 0.088042]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.2094]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9188]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.9588]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.6351]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [2651.53 3387.15 3387.15 7258.5713]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 443.7393]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0306101 -0.0036106]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3840x2160
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        3840x2160_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.23923 1 1 2.7836]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.58915 0.0377625 -0.616429 -0.945174 2.52794 -0.537235 -0.217771 -1.76346 2.9884]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-36.4461 -38.1612 -29.3263]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_104
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [533.326 -38.9322 -38.9322 2476.1192]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 182.7902]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.145974 -0.0036106]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3840x2160
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3840x2160_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.98523 1 1 1.6928]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.1243 -0.955239 -0.160056 -0.585798 2.27098 -0.616837 -0.0192654 -0.974804 2.036]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-36.8576 -44.6401 -45.1663]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_109
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [797.808 508.94 508.94 2977.8141]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 231.5529]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0300834 -0.019091]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3840x2160
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3840x2160_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.48927 1 1 2.4188]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.05797 -0.842641 -0.197003 -0.842204 2.361 -0.441285 -0.076882 -1.19612 2.2813]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-32.4424 -44.2278 -33.9074]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_108
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3840x2160_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [240 240 240 240 240 240 240 240]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [135 135 135 135 135 135 135 135]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3840x2160_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [240 240 240 240 240 240 240 240]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [135 135 135 135 135 135 135 135]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3840x2160_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [240 240 240 240 240 240 240 240]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [135 135 135 135 135 135 135 135]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3840x2160_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [240 240 240 240 240 240 240 240]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [135 135 135 135 135 135 135 135]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_104
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 104]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.58915 0.0377625 -0.616429 -0.945174 2.52794 -0.537235 -0.217771 -1.76346 2.9884]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-36.4461 -38.1612 -29.3263]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.23923 1 1 2.7836]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_109
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 109]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.1243 -0.955239 -0.160056 -0.585798 2.27098 -0.616837 -0.0192654 -0.974804 2.036]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-36.8576 -44.6401 -45.1663]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.98523 1 1 1.6928]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_108
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 108]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.05797 -0.842641 -0.197003 -0.842204 2.361 -0.441285 -0.076882 -1.19612 2.2813]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-32.4424 -44.2278 -33.9074]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.48927 1 1 2.4188]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_108
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 108]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.64855 -1.46973 -0.171784 -0.746979 2.12541 -0.309928 -0.0672896 -1.22039 2.3223]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.8121 -42.8676 -35.6405]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.67897 1 1 2.4837]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3840x2160_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3840x2160_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3840x2160_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [50 50 50 50]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+diff --git a/units/isi/drv/imx678/source/IMX678.c b/units/isi/drv/imx678/source/IMX678.c
+new file mode 100644
+index 0000000..b2d35da
+--- /dev/null
++++ b/units/isi/drv/imx678/source/IMX678.c
+@@ -0,0 +1,1268 @@
++/******************************************************************************\
++|* Copyright (c) 2020 by VeriSilicon Holdings Co., Ltd. ("VeriSilicon")       *|
++|* All Rights Reserved.                                                       *|
++|*                                                                            *|
++|* The material in this file is confidential and contains trade secrets of    *|
++|* of VeriSilicon.  This is proprietary information owned or licensed by      *|
++|* VeriSilicon.  No part of this work may be disclosed, reproduced, copied,   *|
++|* transmitted, or used in any way for any purpose, without the express       *|
++|* written permission of VeriSilicon.                                         *|
++|*                                                                            *|
++\******************************************************************************/
++
++#include <ebase/types.h>
++#include <ebase/trace.h>
++#include <ebase/builtins.h>
++#include <common/return_codes.h>
++#include <common/misc.h>
++#include <sys/ioctl.h>
++#include <fcntl.h>
++#include "isi.h"
++#include "isi_iss.h"
++#include "isi_priv.h"
++#include "vvsensor.h"
++
++CREATE_TRACER( IMX678_INFO , "IMX678: ", INFO,    1);
++CREATE_TRACER( IMX678_WARN , "IMX678: ", WARNING, 1);
++CREATE_TRACER( IMX678_ERROR, "IMX678: ", ERROR,   1);
++
++#ifdef SUBDEV_V4L2
++#include <sys/ioctl.h>
++#include <sys/mman.h>
++#include <fcntl.h>
++#include <linux/videodev2.h>
++#include <linux/v4l2-subdev.h>
++//#undef TRACE
++//#define TRACE(x, ...)
++#endif
++
++static const char SensorName[16] = "imx678";
++
++typedef struct IMX678_Context_s
++{
++    IsiSensorContext_t  IsiCtx;
++    struct vvcam_mode_info_s CurMode;
++    IsiSensorAeInfo_t AeInfo;
++    IsiSensorIntTime_t IntTime;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    IsiSensorGain_t SensorGain;
++    uint32_t minAfps;
++    uint64_t AEStartExposure;
++} IMX678_Context_t;
++
++static RESULT IMX678_IsiSensorSetPowerIss(IsiSensorHandle_t handle, bool_t on)
++{
++    int ret = 0;
++
++    TRACE( IMX678_INFO, "%s: (enter)\n", __func__);
++    TRACE( IMX678_INFO, "%s: set power %d\n", __func__,on);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    int32_t power = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_POWER, &power);
++    if (ret != 0){
++        TRACE(IMX678_ERROR, "%s set power %d error\n", __func__,power);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorGetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (!pclk)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CLK, pclk);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s get clock error\n", __func__);
++        return RET_FAILURE;
++    } 
++    
++    TRACE( IMX678_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++    TRACE( IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorSetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pclk == NULL)
++        return RET_NULL_POINTER;
++    
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_CLK, &pclk);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX678_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++
++    TRACE( IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiResetSensorIss(IsiSensorHandle_t handle)
++{
++    int ret = 0;
++
++    TRACE( IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_RESET, NULL);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s set reset error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiRegisterReadIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        uint32_t * pValue)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_READ_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: read sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    *pValue = sccb_data.data;
++
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiRegisterWriteIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        const uint32_t value)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = value;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_WRITE_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: write sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_UpdateIsiAEInfo(IsiSensorHandle_t handle)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    IsiSensorAeInfo_t *pAeInfo = &pIMX678Ctx->AeInfo;
++    pAeInfo->oneLineExpTime = pIMX678Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++
++    if (pIMX678Ctx->CurMode.hdr_mode == SENSOR_MODE_LINEAR) {
++        pAeInfo->maxIntTime.linearInt =
++            pIMX678Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->minIntTime.linearInt =
++            pIMX678Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->maxAGain.linearGainParas = pIMX678Ctx->CurMode.ae_info.max_again;
++        pAeInfo->minAGain.linearGainParas = pIMX678Ctx->CurMode.ae_info.min_again;
++        pAeInfo->maxDGain.linearGainParas = pIMX678Ctx->CurMode.ae_info.max_dgain;
++        pAeInfo->minDGain.linearGainParas = pIMX678Ctx->CurMode.ae_info.min_dgain;
++    } else {
++        switch (pIMX678Ctx->CurMode.stitching_mode) {
++            case SENSOR_STITCHING_DUAL_DCG:
++            case SENSOR_STITCHING_3DOL:
++            case SENSOR_STITCHING_LINEBYLINE:
++                pAeInfo->maxIntTime.triInt.triSIntTime =
++                    pIMX678Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triSIntTime =
++                    pIMX678Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                
++                pAeInfo->maxIntTime.triInt.triIntTime =
++                    pIMX678Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triIntTime =
++                    pIMX678Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX678Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG) {
++                    pAeInfo->maxIntTime.triInt.triLIntTime = pAeInfo->maxIntTime.triInt.triIntTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime = pAeInfo->minIntTime.triInt.triIntTime;
++                } else {
++                    pAeInfo->maxIntTime.triInt.triLIntTime =
++                        pIMX678Ctx->CurMode.ae_info.max_longintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime =
++                        pIMX678Ctx->CurMode.ae_info.min_longintegration_line * pAeInfo->oneLineExpTime;
++                }
++
++                pAeInfo->maxAGain.triGainParas.triSGain = pIMX678Ctx->CurMode.ae_info.max_short_again;
++                pAeInfo->minAGain.triGainParas.triSGain = pIMX678Ctx->CurMode.ae_info.min_short_again;
++                pAeInfo->maxDGain.triGainParas.triSGain = pIMX678Ctx->CurMode.ae_info.max_short_dgain;
++                pAeInfo->minDGain.triGainParas.triSGain = pIMX678Ctx->CurMode.ae_info.min_short_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triGain = pIMX678Ctx->CurMode.ae_info.max_again;
++                pAeInfo->minAGain.triGainParas.triGain = pIMX678Ctx->CurMode.ae_info.min_again;
++                pAeInfo->maxDGain.triGainParas.triGain = pIMX678Ctx->CurMode.ae_info.max_dgain;
++                pAeInfo->minDGain.triGainParas.triGain = pIMX678Ctx->CurMode.ae_info.min_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triLGain = pIMX678Ctx->CurMode.ae_info.max_long_again;
++                pAeInfo->minAGain.triGainParas.triLGain = pIMX678Ctx->CurMode.ae_info.min_long_again;
++                pAeInfo->maxDGain.triGainParas.triLGain = pIMX678Ctx->CurMode.ae_info.max_long_dgain;
++                pAeInfo->minDGain.triGainParas.triLGain = pIMX678Ctx->CurMode.ae_info.min_long_dgain;
++                break;
++            case SENSOR_STITCHING_DUAL_DCG_NOWAIT:
++            case SENSOR_STITCHING_16BIT_COMPRESS:
++            case SENSOR_STITCHING_L_AND_S:
++            case SENSOR_STITCHING_2DOL:
++                pAeInfo->maxIntTime.dualInt.dualIntTime =
++                    pIMX678Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.dualInt.dualIntTime =
++                    pIMX678Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX678Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime = pAeInfo->maxIntTime.dualInt.dualIntTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime = pAeInfo->minIntTime.dualInt.dualIntTime;
++                } else {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime =
++                        pIMX678Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime =
++                        pIMX678Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                }
++                
++                if (pIMX678Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.min_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.max_long_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.min_long_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.max_long_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.min_long_dgain;
++                } else {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.max_short_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.min_short_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.max_short_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.min_short_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.min_dgain;
++                }
++                
++                break;
++            default:
++                break;
++        }
++    }
++    pAeInfo->gainStep = pIMX678Ctx->CurMode.ae_info.gain_step;
++    pAeInfo->currFps  = pIMX678Ctx->CurMode.ae_info.cur_fps;
++    pAeInfo->maxFps   = pIMX678Ctx->CurMode.ae_info.max_fps;
++    pAeInfo->minFps   = pIMX678Ctx->CurMode.ae_info.min_fps;
++    pAeInfo->minAfps  = pIMX678Ctx->CurMode.ae_info.min_afps;
++    pAeInfo->hdrRatio[0] = pIMX678Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s;
++    pAeInfo->hdrRatio[1] = pIMX678Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs;
++
++    pAeInfo->intUpdateDlyFrm = pIMX678Ctx->CurMode.ae_info.int_update_delay_frm;
++    pAeInfo->gainUpdateDlyFrm = pIMX678Ctx->CurMode.ae_info.gain_update_delay_frm;
++
++    if (pIMX678Ctx->minAfps != 0) {
++        pAeInfo->minAfps = pIMX678Ctx->minAfps;
++    } 
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    memcpy(pMode, &pIMX678Ctx->CurMode, sizeof(IsiSensorMode_t));
++
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    struct vvcam_mode_info_s sensor_mode;
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    sensor_mode.index = pMode->index;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s set sensor mode failed", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX678Ctx->CurMode, &sensor_mode, sizeof(struct vvcam_mode_info_s));
++    IMX678_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorSetStreamingIss(IsiSensorHandle_t handle,
++                                              bool_t on)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    uint32_t status = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_STREAM, &status);
++    if (ret != 0){
++        TRACE(IMX678_ERROR, "%s set sensor stream %d error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: set streaming %d\n", __func__, on);
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiCreateSensorIss(IsiSensorInstanceConfig_t * pConfig)
++{
++    RESULT result = RET_SUCCESS;
++    IMX678_Context_t *pIMX678Ctx;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    if (!pConfig || !pConfig->pSensor || !pConfig->HalHandle)
++        return RET_NULL_POINTER;
++
++    pIMX678Ctx = (IMX678_Context_t *) malloc(sizeof(IMX678_Context_t));
++    if (!pIMX678Ctx)
++        return RET_OUTOFMEM;
++
++    memset(pIMX678Ctx, 0, sizeof(IMX678_Context_t));
++    pIMX678Ctx->IsiCtx.HalHandle = pConfig->HalHandle;
++    pIMX678Ctx->IsiCtx.pSensor   = pConfig->pSensor;
++    pConfig->hSensor = (IsiSensorHandle_t) pIMX678Ctx;
++
++    result = IMX678_IsiSensorSetPowerIss(pIMX678Ctx, BOOL_TRUE);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s set power error\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    result = IMX678_IsiSensorGetClkIss(pIMX678Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s get clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    clk.status = 1;
++    result = IMX678_IsiSensorSetClkIss(pIMX678Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    result = IMX678_IsiResetSensorIss(pIMX678Ctx);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s retset sensor error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    IsiSensorMode_t SensorMode;
++    SensorMode.index = pConfig->SensorModeIndex;
++    result = IMX678_IsiSetSensorModeIss(pIMX678Ctx, &SensorMode);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX678_IsiReleaseSensorIss(IsiSensorHandle_t handle)
++{
++    TRACE(IMX678_INFO, "%s (enter) \n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    if (pIMX678Ctx == NULL)
++        return (RET_WRONG_HANDLE);
++
++    IMX678_IsiSensorSetStreamingIss(pIMX678Ctx, BOOL_FALSE);
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    IMX678_IsiSensorGetClkIss(pIMX678Ctx, &clk);
++    clk.status = 0;
++    IMX678_IsiSensorSetClkIss(pIMX678Ctx, &clk);
++    IMX678_IsiSensorSetPowerIss(pIMX678Ctx, BOOL_FALSE);
++    free(pIMX678Ctx);
++    pIMX678Ctx = NULL;
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiHalQuerySensorIss(HalHandle_t HalHandle,
++                                          IsiSensorModeInfoArray_t *pSensorMode)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter) \n", __func__);
++
++    if (HalHandle == NULL || pSensorMode == NULL)
++        return RET_NULL_POINTER;
++
++    HalContext_t *pHalCtx = (HalContext_t *)HalHandle;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_QUERY, pSensorMode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiQuerySensorIss(IsiSensorHandle_t handle,
++                                       IsiSensorModeInfoArray_t *pSensorMode)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX678_INFO, "%s (enter) \n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    result = IMX678_IsiHalQuerySensorIss(pIMX678Ctx->IsiCtx.HalHandle,
++                                         pSensorMode);
++    if (result != RET_SUCCESS)
++        TRACE(IMX678_ERROR, "%s: query sensor mode info error!\n", __func__);
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX678_IsiGetCapsIss(IsiSensorHandle_t handle,
++                                   IsiSensorCaps_t * pIsiSensorCaps)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX678_INFO, "%s (enter) \n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    IsiSensorModeInfoArray_t SensorModeInfo;
++    memset(&SensorModeInfo, 0, sizeof(IsiSensorModeInfoArray_t));
++    result = IMX678_IsiQuerySensorIss(handle, &SensorModeInfo);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    pIsiSensorCaps->FieldSelection    = ISI_FIELDSEL_BOTH;
++    pIsiSensorCaps->YCSequence        = ISI_YCSEQ_YCBYCR;
++    pIsiSensorCaps->Conv422           = ISI_CONV422_NOCOSITED;
++    pIsiSensorCaps->HPol              = ISI_HPOL_REFPOS;
++    pIsiSensorCaps->VPol              = ISI_VPOL_NEG;
++    pIsiSensorCaps->Edge              = ISI_EDGE_RISING;
++    pIsiSensorCaps->supportModeNum    = SensorModeInfo.count;
++    pIsiSensorCaps->currentMode       = pIMX678Ctx->CurMode.index;
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX678_IsiSetupSensorIss(IsiSensorHandle_t handle,
++                                       const IsiSensorCaps_t *pIsiSensorCaps )
++{
++    int ret = 0;
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    if (pIsiSensorCaps->currentMode != pIMX678Ctx->CurMode.index) {
++        IsiSensorMode_t SensorMode;
++        memset(&SensorMode, 0, sizeof(IsiSensorMode_t));
++        SensorMode.index = pIsiSensorCaps->currentMode;
++        result = IMX678_IsiSetSensorModeIss(handle, &SensorMode);
++        if (result != RET_SUCCESS) {
++            TRACE(IMX678_ERROR, "%s:set sensor mode %d failed!\n",
++                  __func__, SensorMode.index);
++            return result;
++        }
++    }
++
++#ifdef SUBDEV_V4L2
++    struct v4l2_subdev_format format;
++    memset(&format, 0, sizeof(struct v4l2_subdev_format));
++    format.format.width  = pIMX678Ctx->CurMode.size.bounds_width;
++    format.format.height = pIMX678Ctx->CurMode.size.bounds_height;
++    format.which = V4L2_SUBDEV_FORMAT_ACTIVE;
++    format.pad = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VIDIOC_SUBDEV_S_FMT, &format);
++    if (ret != 0){
++        TRACE(IMX678_ERROR, "%s: sensor set format error!\n", __func__);
++        return RET_FAILURE;
++    }
++#else
++    ret = ioctrl(pHalCtx->sensor_fd, VVSENSORIOC_S_INIT, NULL);
++    if (ret != 0){
++        TRACE(IMX678_ERROR, "%s: sensor init error!\n", __func__);
++        return RET_FAILURE;
++    }
++#endif
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetSensorRevisionIss(IsiSensorHandle_t handle, uint32_t *pValue)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pValue == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CHIP_ID, pValue);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: get chip id error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiCheckSensorConnectionIss(IsiSensorHandle_t handle)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    uint32_t ChipId = 0;
++    result = IMX678_IsiGetSensorRevisionIss(handle, &ChipId);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s:get sensor chip id error!\n",__func__);
++        return RET_FAILURE;
++    }
++
++    if (ChipId != 678) {
++        TRACE(IMX678_ERROR,
++            "%s:ChipID=678,while read sensor Id=0x%x error!\n",
++             __func__, ChipId);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetAeInfoIss(IsiSensorHandle_t handle,
++                                     IsiSensorAeInfo_t *pAeInfo)
++{
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    if (pAeInfo == NULL)
++        return RET_NULL_POINTER;
++
++    memcpy(pAeInfo, &pIMX678Ctx->AeInfo, sizeof(IsiSensorAeInfo_t));
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetHdrRatioIss(IsiSensorHandle_t handle,
++                                       uint8_t hdrRatioNum,
++                                       uint32_t HdrRatio[])
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    struct sensor_hdr_artio_s hdr_ratio;
++    if (hdrRatioNum == 2) {
++        hdr_ratio.ratio_s_vs = HdrRatio[1];
++        hdr_ratio.ratio_l_s = HdrRatio[0];
++    }else {
++        hdr_ratio.ratio_s_vs = HdrRatio[0];
++        hdr_ratio.ratio_l_s = 0;
++    }
++
++    if (hdr_ratio.ratio_s_vs == pIMX678Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs &&
++        hdr_ratio.ratio_l_s == pIMX678Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s)
++        return RET_SUCCESS;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_HDR_RADIO, &hdr_ratio);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR,"%s: set hdr ratio error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s sensor_mode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR,"%s: get mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memcpy(&pIMX678Ctx->CurMode, &sensor_mode, sizeof (struct vvcam_mode_info_s));
++    IMX678_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    memcpy(pIntegrationTime, &pIMX678Ctx->IntTime, sizeof(IsiSensorIntTime_t));
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++
++}
++
++static RESULT IMX678_IsiSetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    int ret = 0;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    uint32_t oneLineTime;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++    printf("\n\nAAAAAAAAAAAAAAA %u\n\n", pIntegrationTime->IntegrationTime.linearInt);
++    if (pIntegrationTime == NULL)
++        return RET_NULL_POINTER;
++
++    oneLineTime =  pIMX678Ctx->AeInfo.oneLineExpTime;
++    pIMX678Ctx->IntTime.expoFrmType = pIntegrationTime->expoFrmType;
++
++    switch (pIntegrationTime->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            IntLine = pIntegrationTime->IntegrationTime.linearInt;
++            if (IntLine != pIMX678Ctx->IntLine) {
++                printf("\n\ngoing into S_EXP ioctl %u\n\n", IntLine);
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor linear exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++               pIMX678Ctx->IntLine = IntLine;
++            }
++            TRACE(IMX678_INFO, "%s set linear exp %d \n", __func__,IntLine);
++            pIMX678Ctx->IntTime.IntegrationTime.linearInt =  IntLine * oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            IntLine = pIntegrationTime->IntegrationTime.dualInt.dualIntTime;
++            if (IntLine != pIMX678Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor dual exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX678Ctx->IntLine = IntLine;
++            }
++
++            if (pIMX678Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                ShortIntLine = pIntegrationTime->IntegrationTime.dualInt.dualSIntTime;
++                if (ShortIntLine != pIMX678Ctx->ShortIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX678_ERROR,"%s:set sensor dual vsexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX678Ctx->ShortIntLine = ShortIntLine;
++                }
++            } else {
++                ShortIntLine = IntLine;
++                pIMX678Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX678_INFO, "%s set dual exp %d short_exp %d\n", __func__, IntLine, ShortIntLine);
++            pIMX678Ctx->IntTime.IntegrationTime.dualInt.dualIntTime  = IntLine + oneLineTime;
++            pIMX678Ctx->IntTime.IntegrationTime.dualInt.dualSIntTime = ShortIntLine + oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            if (pIMX678Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triLIntTime;
++                if (LongIntLine != pIMX678Ctx->LongIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_EXP, &LongIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX678_ERROR,"%s:set sensor tri lexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX678Ctx->LongIntLine = LongIntLine;
++                }
++            } else {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++                pIMX678Ctx->LongIntLine = LongIntLine;
++            }
++
++            IntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++            if (IntLine != pIMX678Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX678Ctx->IntLine = IntLine;
++            }
++            
++            ShortIntLine = pIntegrationTime->IntegrationTime.triInt.triSIntTime;
++            if (ShortIntLine != pIMX678Ctx->ShortIntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri vsexp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX678Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX678_INFO, "%s set tri long exp %d exp %d short_exp %d\n", __func__, LongIntLine, IntLine, ShortIntLine);
++            pIMX678Ctx->IntTime.IntegrationTime.triInt.triLIntTime = LongIntLine + oneLineTime;
++            pIMX678Ctx->IntTime.IntegrationTime.triInt.triIntTime = IntLine + oneLineTime;
++            pIMX678Ctx->IntTime.IntegrationTime.triInt.triSIntTime = ShortIntLine + oneLineTime;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++    
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++    memcpy(pGain, &pIMX678Ctx->SensorGain, sizeof(IsiSensorGain_t));
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    int ret = 0;
++    uint32_t LongGain;
++    uint32_t Gain;
++    uint32_t ShortGain;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++
++    pIMX678Ctx->SensorGain.expoFrmType = pGain->expoFrmType;
++    switch (pGain->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            Gain = pGain->gain.linearGainParas;
++            if (pIMX678Ctx->SensorGain.gain.linearGainParas != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor linear gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            pIMX678Ctx->SensorGain.gain.linearGainParas = pGain->gain.linearGainParas;
++            TRACE(IMX678_INFO, "%s set linear gain %d\n", __func__,pGain->gain.linearGainParas);
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            Gain = pGain->gain.dualGainParas.dualGain;
++            if (pIMX678Ctx->SensorGain.gain.dualGainParas.dualGain != Gain) {
++                if (pIMX678Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &Gain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor dual gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.dualGainParas.dualSGain;
++            if (pIMX678Ctx->SensorGain.gain.dualGainParas.dualSGain != ShortGain) {
++                if (pIMX678Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &ShortGain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor dual vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX678_INFO,"%s:set gain%d short gain %d!\n", __func__,Gain,ShortGain);
++            pIMX678Ctx->SensorGain.gain.dualGainParas.dualGain = Gain;
++            pIMX678Ctx->SensorGain.gain.dualGainParas.dualSGain = ShortGain;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            LongGain = pGain->gain.triGainParas.triLGain;
++            if (pIMX678Ctx->SensorGain.gain.triGainParas.triLGain != LongGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &LongGain);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            Gain = pGain->gain.triGainParas.triGain;
++            if (pIMX678Ctx->SensorGain.gain.triGainParas.triGain != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.triGainParas.triSGain;
++            if (pIMX678Ctx->SensorGain.gain.triGainParas.triSGain != ShortGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX678_INFO,"%s:set long gain %d gain%d short gain %d!\n", __func__, LongGain, Gain, ShortGain);
++            pIMX678Ctx->SensorGain.gain.triGainParas.triLGain = LongGain;
++            pIMX678Ctx->SensorGain.gain.triGainParas.triGain = Gain;
++            pIMX678Ctx->SensorGain.gain.triGainParas.triSGain = ShortGain;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++
++static RESULT IMX678_IsiGetSensorFpsIss(IsiSensorHandle_t handle, uint32_t * pfps)
++{
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    if (pfps == NULL)
++        return RET_NULL_POINTER;
++
++    *pfps = pIMX678Ctx->CurMode.ae_info.cur_fps;
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetSensorFpsIss(IsiSensorHandle_t handle, uint32_t fps)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_FPS, &fps);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR,"%s:set sensor fps error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s SensorMode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &SensorMode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR,"%s:get sensor mode error!\n", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX678Ctx->CurMode, &SensorMode, sizeof(struct vvcam_mode_info_s));
++    IMX678_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++static RESULT IMX678_IsiSetSensorAfpsLimitsIss(IsiSensorHandle_t handle, uint32_t minAfps)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    if ((minAfps > pIMX678Ctx->CurMode.ae_info.max_fps) ||
++        (minAfps < pIMX678Ctx->CurMode.ae_info.min_fps))
++        return RET_FAILURE;
++    pIMX678Ctx->minAfps = minAfps;
++    pIMX678Ctx->CurMode.ae_info.min_afps = minAfps;
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetSensorIspStatusIss(IsiSensorHandle_t handle,
++                               IsiSensorIspStatus_t *pSensorIspStatus)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    if (pIMX678Ctx->CurMode.hdr_mode == SENSOR_MODE_HDR_NATIVE) {
++        pSensorIspStatus->useSensorAWB = true;
++        pSensorIspStatus->useSensorBLC = true;
++    } else {
++        pSensorIspStatus->useSensorAWB = false;
++        pSensorIspStatus->useSensorBLC = false;
++    }
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++#ifndef ISI_LITE
++static RESULT IMX678_IsiSensorSetBlcIss(IsiSensorHandle_t handle, IsiSensorBlc_t * pBlc)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pBlc == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_blc_s SensorBlc;
++    SensorBlc.red = pBlc->red;
++    SensorBlc.gb = pBlc->gb;
++    SensorBlc.gr = pBlc->gr;
++    SensorBlc.blue = pBlc->blue;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_BLC, &SensorBlc);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorSetWBIss(IsiSensorHandle_t handle, IsiSensorWB_t *pWb)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pWb == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_white_balance_s SensorWb;
++    SensorWb.r_gain = pWb->r_gain;
++    SensorWb.gr_gain = pWb->gr_gain;
++    SensorWb.gb_gain = pWb->gb_gain;
++    SensorWb.b_gain = pWb->b_gain;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_WB, &SensorWb);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorGetExpandCurveIss(IsiSensorHandle_t handle, IsiSensorExpandCurve_t *pExpandCurve)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pExpandCurve == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_EXPAND_CURVE, pExpandCurve);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: get  expand cure error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetTestPatternIss(IsiSensorHandle_t handle,
++                                       IsiSensorTpgMode_e  tpgMode)
++{
++    int32_t ret = 0;
++
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    struct sensor_test_pattern_s TestPattern;
++    if (tpgMode == ISI_TPG_DISABLE) {
++        TestPattern.enable = 0;
++        TestPattern.pattern = 0;
++    } else {
++        TestPattern.enable = 1;
++        TestPattern.pattern = (uint32_t)tpgMode - 1;
++    }
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_TEST_PATTERN, &TestPattern);
++    if (ret != 0)
++    {
++        TRACE(IMX678_ERROR, "%s: set test pattern %d error\n", __func__, tpgMode);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: test pattern enable[%d] mode[%d]\n", __func__, TestPattern.enable, TestPattern.pattern);
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiFocusSetupIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiFocusReleaseIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiFocusGetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiFocusSetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetFocusCalibrateIss(IsiSensorHandle_t handle, IsiFoucsCalibAttr_t *pFocusCalib)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t *pExposure)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    if (pIMX678Ctx->AEStartExposure == 0) {
++        pIMX678Ctx->AEStartExposure =
++            (uint64_t)pIMX678Ctx->CurMode.ae_info.start_exposure *
++            pIMX678Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++           
++    }
++    *pExposure =  pIMX678Ctx->AEStartExposure;
++    TRACE(IMX678_INFO, "%s:get start exposure %d\n", __func__, pIMX678Ctx->AEStartExposure);
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t exposure)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    pIMX678Ctx->AEStartExposure = exposure;
++    TRACE(IMX678_INFO, "set start exposure %d\n", __func__,pIMX678Ctx->AEStartExposure);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++#endif
++
++RESULT IMX678_IsiGetSensorIss(IsiSensor_t *pIsiSensor)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++
++    if (pIsiSensor == NULL)
++        return RET_NULL_POINTER;
++     pIsiSensor->pszName                         = SensorName;
++     pIsiSensor->pIsiSensorSetPowerIss           = IMX678_IsiSensorSetPowerIss;
++     pIsiSensor->pIsiCreateSensorIss             = IMX678_IsiCreateSensorIss;
++     pIsiSensor->pIsiReleaseSensorIss            = IMX678_IsiReleaseSensorIss;
++     pIsiSensor->pIsiRegisterReadIss             = IMX678_IsiRegisterReadIss;
++     pIsiSensor->pIsiRegisterWriteIss            = IMX678_IsiRegisterWriteIss;
++     pIsiSensor->pIsiGetSensorModeIss            = IMX678_IsiGetSensorModeIss;
++     pIsiSensor->pIsiSetSensorModeIss            = IMX678_IsiSetSensorModeIss;
++     pIsiSensor->pIsiQuerySensorIss              = IMX678_IsiQuerySensorIss;
++     pIsiSensor->pIsiGetCapsIss                  = IMX678_IsiGetCapsIss;
++     pIsiSensor->pIsiSetupSensorIss              = IMX678_IsiSetupSensorIss;
++     pIsiSensor->pIsiGetSensorRevisionIss        = IMX678_IsiGetSensorRevisionIss;
++     pIsiSensor->pIsiCheckSensorConnectionIss    = IMX678_IsiCheckSensorConnectionIss;
++     pIsiSensor->pIsiSensorSetStreamingIss       = IMX678_IsiSensorSetStreamingIss;
++     pIsiSensor->pIsiGetAeInfoIss                = IMX678_IsiGetAeInfoIss;
++     pIsiSensor->pIsiSetHdrRatioIss              = IMX678_IsiSetHdrRatioIss;
++     pIsiSensor->pIsiGetIntegrationTimeIss       = IMX678_IsiGetIntegrationTimeIss;
++     pIsiSensor->pIsiSetIntegrationTimeIss       = IMX678_IsiSetIntegrationTimeIss;
++     pIsiSensor->pIsiGetGainIss                  = IMX678_IsiGetGainIss;
++     pIsiSensor->pIsiSetGainIss                  = IMX678_IsiSetGainIss;
++     pIsiSensor->pIsiGetSensorFpsIss             = IMX678_IsiGetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorFpsIss             = IMX678_IsiSetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorAfpsLimitsIss      = IMX678_IsiSetSensorAfpsLimitsIss;
++     pIsiSensor->pIsiGetSensorIspStatusIss       = IMX678_IsiGetSensorIspStatusIss;
++#ifndef ISI_LITE
++    pIsiSensor->pIsiSensorSetBlcIss              = IMX678_IsiSensorSetBlcIss;
++    pIsiSensor->pIsiSensorSetWBIss               = IMX678_IsiSensorSetWBIss;
++    pIsiSensor->pIsiSensorGetExpandCurveIss      = IMX678_IsiSensorGetExpandCurveIss;
++    pIsiSensor->pIsiActivateTestPatternIss       = IMX678_IsiSetTestPatternIss;
++    pIsiSensor->pIsiFocusSetupIss                = IMX678_IsiFocusSetupIss;
++    pIsiSensor->pIsiFocusReleaseIss              = IMX678_IsiFocusReleaseIss;
++    pIsiSensor->pIsiFocusSetIss                  = IMX678_IsiFocusSetIss;
++    pIsiSensor->pIsiFocusGetIss                  = IMX678_IsiFocusGetIss;
++    pIsiSensor->pIsiGetFocusCalibrateIss         = IMX678_IsiGetFocusCalibrateIss;
++    pIsiSensor->pIsiSetAeStartExposureIss        = IMX678_IsiSetAeStartExposureIs;
++    pIsiSensor->pIsiGetAeStartExposureIss        = IMX678_IsiGetAeStartExposureIs;
++#endif
++    TRACE( IMX678_INFO, "%s (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++/*****************************************************************************
++* each sensor driver need declare this struct for isi load
++*****************************************************************************/
++IsiCamDrvConfig_t IsiCamDrvConfig = {
++    .CameraDriverID = 0x0678,
++    .pIsiHalQuerySensor = IMX678_IsiHalQuerySensorIss,
++    .pfIsiGetSensorIss = IMX678_IsiGetSensorIss,
++};

--- a/isp/imx8mp/framos/Torizon6/isp-imx/patches/patch.sh
+++ b/isp/imx8mp/framos/Torizon6/isp-imx/patches/patch.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Apply patches 
+patch -d /downloads/isp-imx-${ISP_IMX_VERSION}/ -p1 < 0001-isp-imx-start_isp-don-t-report-error-if-no-camera-is.patch 
+patch -d /downloads/isp-imx-${ISP_IMX_VERSION}/ -p1 < 0002-Add-support-for-imx6xx-sensors.patch 

--- a/isp/imx8mp/framos/Torizon6/isp-imx/patches/sed-bash.sh
+++ b/isp/imx8mp/framos/Torizon6/isp-imx/patches/sed-bash.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sed -i 's|^#!/bin/sh|#!/bin/bash|' /downloads/isp-imx-${ISP_IMX_VERSION}/build_output_release_v4l2/opt/imx8-isp/bin/start_isp.sh
+sed -i 's|^#!/bin/sh|#!/bin/bash|' /downloads/isp-imx-${ISP_IMX_VERSION}/build_output_release_v4l2/opt/imx8-isp/bin/run.sh

--- a/isp/imx8mp/framos/Torizon7/docker-compose.yaml
+++ b/isp/imx8mp/framos/Torizon7/docker-compose.yaml
@@ -1,0 +1,66 @@
+version: '3'
+
+services:
+  weston:
+    image: torizon/weston-imx8:4
+    container_name: weston
+    command:
+      - --tty=/dev/tty7
+    environment:
+      - ACCEPT_FSL_EULA=1
+      - WESTON_DISABLE_ATOMIC=1
+    network_mode: host
+    cap_add:
+      - CAP_SYS_TTY_CONFIG
+    volumes:
+      - /dev/:/dev/
+      - /tmp:/tmp
+      - /run/udev/:/run/udev/
+    device_cgroup_rules:
+      - 'c 4:* rmw'
+      - 'c 13:* rmw'
+      - 'c 199:* rmw'
+      - 'c 226:* rmw'
+
+  isp-imx:
+    image: <your-dockerhub-username>/torizon7-isp-imx
+    container_name: isp-imx
+    working_dir: /build-isp-imx/opt/imx8-isp/bin/
+    command: ["./start_isp.sh", "sleep 3"]
+    environment:
+      - ACCEPT_FSL_EULA=1
+    cap_add:
+      - CAP_SYS_TTY_CONFIG
+    volumes:
+      - /tmp:/tmp
+      - /var/run/dbus:/var/run/dbus
+      - /dev:/dev
+      - /sys:/sys
+      - /lib/modules:/lib/modules
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+    tty: true
+    depends_on:
+      - weston
+    privileged: true
+    pull_policy: always
+
+  gstreamer:
+    image: <your-dockerhub-username>/gst_example
+    container_name: gstreamer
+    entrypoint: ["gst-launch-1.0", "-v", "v4l2src", "device=/dev/video2", "!", "video/x-raw", "!", "videoconvert", "!", "waylandsink"]
+    volumes:
+      - /var/rootdirs/media:/media:z
+      - /tmp:/tmp
+      - /var/run/dbus:/var/run/dbus
+      - /dev:/dev
+    device_cgroup_rules:
+      - 'c 199:* rmw'
+      - 'c 226:* rmw'
+      - 'c 81:* rmw'
+    depends_on:
+      isp-imx:
+        condition: service_healthy

--- a/isp/imx8mp/framos/Torizon7/isp-imx/Dockerfile
+++ b/isp/imx8mp/framos/Torizon7/isp-imx/Dockerfile
@@ -1,0 +1,78 @@
+ARG BASE_NAME=wayland-base-vivante
+ARG IMAGE_ARCH=linux/arm64
+ARG IMAGE_TAG=3
+ARG DOCKER_REGISTRY=torizon
+
+FROM --platform=$IMAGE_ARCH $DOCKER_REGISTRY/$BASE_NAME:$IMAGE_TAG AS framos-build
+
+ARG ISP_IMX_VERSION="4.2.2.24.0"
+ARG ACCEPT_FSL_EULA=1
+ARG ISP_IMX_URL="https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/isp-imx-$ISP_IMX_VERSION.bin"
+
+## Install build dependencies
+
+RUN apt-get -y update && apt-get install -y \
+    cmake build-essential gcc g++ git wget unzip patchelf \
+    autoconf automake libtool curl gfortran libboost-all-dev \
+    libwayland-dev libdrm-dev libg2d-dpu-dev libg2d-dpu \
+    libtinyxml2-dev linux-imx-headers-dev patch kmod
+
+# Create Symlinks for libraries
+
+RUN ln -s /usr/lib/aarch64-linux-gnu/libtinyxml2.so /usr/lib/libtinyxml2.so
+RUN ln -s /usr/include/libdrm /usr/include/drm
+
+WORKDIR downloads
+
+# download and extract isp-imx from NXP site
+
+RUN wget -O isp-imx-$ISP_IMX_VERSION.bin $ISP_IMX_URL
+RUN chmod +x isp-imx-$ISP_IMX_VERSION.bin
+RUN ./isp-imx-$ISP_IMX_VERSION.bin --auto-accept --force
+
+# apply patches for framos cameras
+
+COPY patches/ /downloads/isp-imx-$ISP_IMX_VERSION/patches
+
+WORKDIR /downloads/isp-imx-$ISP_IMX_VERSION/patches
+RUN ./patch.sh
+
+# build isp-imx
+
+WORKDIR /downloads/isp-imx-$ISP_IMX_VERSION/
+RUN ./build-all-isp.sh Release v4l2
+
+# apply patch to use bash instead of sh in some isp scripts
+WORKDIR /downloads/isp-imx-$ISP_IMX_VERSION/patches
+RUN ./sed-bash.sh
+
+FROM --platform=$IMAGE_ARCH $DOCKER_REGISTRY/$BASE_NAME:$IMAGE_TAG AS framos-base
+
+ARG ISP_IMX_VERSION=4.2.2.24.0
+ARG ACCEPT_FSL_EULA=1
+ARG SRC_DIR=/downloads/isp-imx-${ISP_IMX_VERSION}
+ARG BUILD_DIR=${SRC_DIR}/build_output_release_v4l2
+ARG INSTALL_DIR=/build-isp-imx/opt/imx8-isp
+
+WORKDIR /build-isp-imx/opt/imx8-isp/
+RUN mkdir -p /build-isp-imx/opt/imx8-isp/bin
+RUN mkdir -p /build-isp-imx/opt/imx8-isp/bin/dewarp_config
+RUN mkdir -p /build-isp-imx/opt/imx8-isp/lib
+RUN mkdir -p /build-isp-imx/opt/imx8-isp/include
+
+RUN apt-get -y update && apt-get install -y tree kmod libtinyxml2-dev procps
+
+## Copy compiled binaries, libraries, and other files
+COPY --from=framos-build /downloads/isp-imx-$ISP_IMX_VERSION/build_output_release_v4l2/opt/imx8-isp/bin/video_test /build-isp-imx/opt/imx8-isp/bin
+COPY --from=framos-build /downloads/isp-imx-$ISP_IMX_VERSION/build_output_release_v4l2/opt/imx8-isp/bin/IMX*.xml /build-isp-imx/opt/imx8-isp/bin/
+COPY --from=framos-build /downloads/isp-imx-$ISP_IMX_VERSION/build_output_release_v4l2/opt/imx8-isp/bin/imx*.drv /build-isp-imx/opt/imx8-isp/bin/
+COPY --from=framos-build $SRC_DIR/dewarp/dewarp_config/ $INSTALL_DIR/bin/dewarp_config
+COPY --from=framos-build $BUILD_DIR/opt/imx8-isp/bin/isp_media_server $INSTALL_DIR/bin
+COPY --from=framos-build $BUILD_DIR/opt/imx8-isp/bin/vvext $INSTALL_DIR/bin
+COPY --from=framos-build $BUILD_DIR/usr/lib/ $INSTALL_DIR/lib/
+RUN cp $INSTALL_DIR/lib/lib*.so* /usr/lib/
+
+# Copy any extra scripts from source
+COPY --from=framos-build $BUILD_DIR/opt/imx8-isp/bin/start_isp.sh $INSTALL_DIR/bin
+COPY --from=framos-build $BUILD_DIR/opt/imx8-isp/bin/run.sh $INSTALL_DIR/bin
+RUN chmod +x $INSTALL_DIR/bin/run.sh $INSTALL_DIR/bin/start_isp.sh

--- a/isp/imx8mp/framos/Torizon7/isp-imx/patches/0001-isp-imx-start_isp-don-t-report-error-if-no-camera-is.patch
+++ b/isp/imx8mp/framos/Torizon7/isp-imx/patches/0001-isp-imx-start_isp-don-t-report-error-if-no-camera-is.patch
@@ -1,0 +1,32 @@
+From 3443f18dc9ab8950071d6299c7a5da86055f3318 Mon Sep 17 00:00:00 2001
+From: Max Krummenacher <max.krummenacher@toradex.com>
+Date: Thu, 19 Jan 2023 15:51:24 +0000
+Subject: [PATCH] isp-imx: start_isp: don't report error if no camera is
+ configured
+
+The script currently returns '6' when no known camera is configured
+in the device tree. The end result is that the systemd imx8-isp.service
+goes to the failed state.
+Return '0' in that case as obviously the device tree doesn't have a
+camera configured and the service is not needed.
+
+Related-to: ELB-5002
+Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>
+---
+ imx/start_isp.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/imx/start_isp.sh b/imx/start_isp.sh
+index 95cbc19..d603f8f 100755
+--- a/imx/start_isp.sh
++++ b/imx/start_isp.sh
+@@ -74,5 +74,5 @@ elif [ $NR_DEVICE_TREE_OS08A20 -eq 2 ]; then
+ else
+ 	# no device tree found exit with code no device or address
+ 	echo "No device tree found for Basler camera or os08a20, check dtb file!" >&2
+-	exit 6
++	exit 0
+ fi
+-- 
+2.35.3
+

--- a/isp/imx8mp/framos/Torizon7/isp-imx/patches/0002-Add-support-for-imx6xx-sensors.patch
+++ b/isp/imx8mp/framos/Torizon7/isp-imx/patches/0002-Add-support-for-imx6xx-sensors.patch
@@ -1,0 +1,16514 @@
+From 2353252582ead3c4f34e46f4805e68849a8f659a Mon Sep 17 00:00:00 2001
+From: Marcio Albano Hermelino Ferreira <marcio.ferreira@toradex.com>
+Date: Tue, 26 Nov 2024 19:17:58 -0300
+Subject: [PATCH] Add support for imx6xx sensors
+
+---
+ build-all-isp.sh                              |    6 +
+ .../sensor_dwe_IMX662_Basic_1280x720.json     |   54 +
+ .../sensor_dwe_IMX662_Basic_1920x1080.json    |   54 +
+ .../sensor_dwe_IMX662_Basic_640x480.json      |   54 +
+ .../sensor_dwe_IMX662_Basic_960x540.json      |   54 +
+ .../sensor_dwe_IMX676_Basic_1760x1070.json    |   54 +
+ .../sensor_dwe_IMX676_Basic_1776x1778.json    |   54 +
+ .../sensor_dwe_IMX676_Basic_3536x2140.json    |   54 +
+ .../sensor_dwe_IMX676_Basic_3536x3072.json    |   54 +
+ .../sensor_dwe_IMX678_Basic_1920x1080.json    |   54 +
+ .../sensor_dwe_IMX678_Basic_3840x2160.json    |   54 +
+ imx/run.sh                                    |  102 ++
+ imx/start_isp.sh                              |   60 +-
+ units/isi/CMakeLists.txt                      |    6 +
+ units/isi/drv/imx662/CMakeLists.txt           |  122 ++
+ units/isi/drv/imx662/Sensor0_Entry.cfg        |   15 +
+ units/isi/drv/imx662/Sensor1_Entry.cfg        |   15 +
+ units/isi/drv/imx662/calib/CMakeLists.txt     |   43 +
+ .../calib/IMX662/IMX662_Basic_1280x720.xml    | 1103 ++++++++++++++
+ .../calib/IMX662/IMX662_Basic_1920x1080.xml   | 1103 ++++++++++++++
+ .../calib/IMX662/IMX662_Basic_640x480.xml     | 1103 ++++++++++++++
+ .../calib/IMX662/IMX662_Basic_960x540.xml     | 1103 ++++++++++++++
+ units/isi/drv/imx662/source/IMX662.c          | 1268 +++++++++++++++++
+ units/isi/drv/imx676/CMakeLists.txt           |  122 ++
+ units/isi/drv/imx676/Sensor0_Entry.cfg        |   15 +
+ units/isi/drv/imx676/Sensor1_Entry.cfg        |   15 +
+ units/isi/drv/imx676/calib/CMakeLists.txt     |   42 +
+ .../calib/IMX676/IMX676_Basic_1760x1070.xml   | 1103 ++++++++++++++
+ .../calib/IMX676/IMX676_Basic_1776x1778.xml   | 1103 ++++++++++++++
+ .../calib/IMX676/IMX676_Basic_3536x2140.xml   | 1103 ++++++++++++++
+ .../calib/IMX676/IMX676_Basic_3536x3072.xml   | 1103 ++++++++++++++
+ units/isi/drv/imx676/source/IMX676.c          | 1268 +++++++++++++++++
+ units/isi/drv/imx678/CMakeLists.txt           |  122 ++
+ units/isi/drv/imx678/Sensor0_Entry.cfg        |    9 +
+ units/isi/drv/imx678/Sensor1_Entry.cfg        |    9 +
+ units/isi/drv/imx678/calib/CMakeLists.txt     |   42 +
+ .../calib/IMX678/IMX678_Basic_1920x1080.xml   | 1103 ++++++++++++++
+ .../calib/IMX678/IMX678_Basic_3840x2160.xml   | 1103 ++++++++++++++
+ units/isi/drv/imx678/source/IMX678.c          | 1268 +++++++++++++++++
+ 39 files changed, 16117 insertions(+), 2 deletions(-)
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json
+ create mode 100644 dewarp/dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json
+ create mode 100644 units/isi/drv/imx662/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx662/Sensor0_Entry.cfg
+ create mode 100644 units/isi/drv/imx662/Sensor1_Entry.cfg
+ create mode 100644 units/isi/drv/imx662/calib/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1280x720.xml
+ create mode 100644 units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1920x1080.xml
+ create mode 100644 units/isi/drv/imx662/calib/IMX662/IMX662_Basic_640x480.xml
+ create mode 100644 units/isi/drv/imx662/calib/IMX662/IMX662_Basic_960x540.xml
+ create mode 100644 units/isi/drv/imx662/source/IMX662.c
+ create mode 100644 units/isi/drv/imx676/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx676/Sensor0_Entry.cfg
+ create mode 100644 units/isi/drv/imx676/Sensor1_Entry.cfg
+ create mode 100644 units/isi/drv/imx676/calib/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1760x1070.xml
+ create mode 100644 units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1776x1778.xml
+ create mode 100644 units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x2140.xml
+ create mode 100644 units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x3072.xml
+ create mode 100644 units/isi/drv/imx676/source/IMX676.c
+ create mode 100644 units/isi/drv/imx678/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx678/Sensor0_Entry.cfg
+ create mode 100644 units/isi/drv/imx678/Sensor1_Entry.cfg
+ create mode 100644 units/isi/drv/imx678/calib/CMakeLists.txt
+ create mode 100644 units/isi/drv/imx678/calib/IMX678/IMX678_Basic_1920x1080.xml
+ create mode 100644 units/isi/drv/imx678/calib/IMX678/IMX678_Basic_3840x2160.xml
+ create mode 100644 units/isi/drv/imx678/source/IMX678.c
+
+diff --git a/build-all-isp.sh b/build-all-isp.sh
+index 607286f..4d90843 100755
+--- a/build-all-isp.sh
++++ b/build-all-isp.sh
+@@ -89,6 +89,12 @@ fi
+ cp -a appshell/build/generated/${BUILD_DIR}/lib/*.so* ${ISP_LIB_DIR}
+ cp -a appshell/build/generated/${BUILD_TYPE}/bin/OS08a20* ${ISP_BIN_DIR}
+ cp -a appshell/build/generated/${BUILD_TYPE}/bin/os08a20* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/IMX662* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/imx662* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/IMX676* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/imx676* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/IMX678* ${ISP_BIN_DIR}
++cp -a appshell/build/generated/${BUILD_TYPE}/bin/imx678* ${ISP_BIN_DIR}
+ cp -a appshell/build/generated/${BUILD_TYPE}/bin/isp_media_server ${ISP_BIN_DIR}
+ cp -a appshell/build/generated/${BUILD_TYPE}/bin/*_test ${ISP_BIN_DIR}
+ cp -a appshell/build/generated/${BUILD_DIR}/bin/*.cfg ${ISP_BIN_DIR}/
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json
+new file mode 100644
+index 0000000..a8885c0
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1280,
++                "height": 720
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 360,
++                "vertical_line_up": 640,
++                "vertical_line_down": 640
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                640.0,
++                0.0,
++                1000.0,
++                360.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}--- dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json
+new file mode 100644
+index 0000000..4f878aa
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1920,
++                "height": 1080
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 540,
++                "vertical_line_up": 960,
++                "vertical_line_down": 960
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                960.0,
++                0.0,
++                1000.0,
++                540.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}--- dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json
+new file mode 100644
+index 0000000..7c4efff
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_640x480.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 640,
++                "height": 480
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 240,
++                "vertical_line_up": 320,
++                "vertical_line_down": 320
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                320.0,
++                0.0,
++                1000.0,
++                240.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}--- dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json
+new file mode 100644
+index 0000000..37bfed5
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX662_Basic_960x540.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 960,
++                "height": 540
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 270,
++                "vertical_line_up": 480,
++                "vertical_line_down": 480
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                480.0,
++                0.0,
++                1000.0,
++                270.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}--- imx/run.sh
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json
+new file mode 100644
+index 0000000..9c608e3
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1760,
++                "height": 1070
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 535,
++                "vertical_line_up": 880,
++                "vertical_line_down": 880
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                320.0,
++                0.0,
++                1000.0,
++                240.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json
+new file mode 100644
+index 0000000..597e60b
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1776,
++                "height": 1778
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 889,
++                "vertical_line_up": 888,
++                "vertical_line_down": 888
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                888.0,
++                0.0,
++                1000.0,
++                889.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json
+new file mode 100644
+index 0000000..c3261cd
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 3536,
++                "height": 2140
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 1070,
++                "vertical_line_up": 1768,
++                "vertical_line_down": 1768
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                1768.0,
++                0.0,
++                1000.0,
++                1070.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json
+new file mode 100644
+index 0000000..a862edb
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 3536,
++                "height": 3072
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 1536,
++                "vertical_line_up": 1768,
++                "vertical_line_down": 1768
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                1768.0,
++                0.0,
++                1000.0,
++                1536.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json b/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json
+new file mode 100644
+index 0000000..e7351ce
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 1920,
++                "height": 1080
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 540,
++                "vertical_line_up": 960,
++                "vertical_line_down": 960
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                960.0,
++                0.0,
++                1000.0,
++                540.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json b/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json
+new file mode 100644
+index 0000000..ad9c7ae
+--- /dev/null
++++ b/dewarp/dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json
+@@ -0,0 +1,54 @@
++{
++    "dewarpConfigArray": [
++        {
++            "source_image": {
++                "width": 3840,
++                "height": 2160
++            },
++            "?dewarpType": "LENS_CORRECTION, FISHEYE_EXPAND, SPLIT_SCREEN",
++            "dewarpType": "LENS_CORRECTION",
++            "scale": {
++                "roix": 0,
++                "roiy": 0,
++                "factor": 1.0
++            },
++            "split": {
++                "horizon_line": 1080,
++                "vertical_line_up": 1920,
++                "vertical_line_down": 1920
++            },
++            "bypass": true,
++            "hflip": false,
++            "vflip": false,
++            "camera_matrix": [
++                1000.0,
++                0.0,
++                1920.0,
++                0.0,
++                1000.0,
++                1080.0,
++                0.0,
++                0.0,
++                1.0
++            ],
++            "distortion_coeff": [
++                0.0,
++                0.0,
++                0.0,
++                0.0,
++                0.0
++            ],
++            "perspective": [
++                1.0,
++                0,
++                0,
++                0,
++                1,
++                0,
++                0,
++                0,
++                1
++            ]
++        }
++    ]
++}
+\ No newline at end of file
+diff --git a/imx/run.sh b/imx/run.sh
+index a9506d0..ea92b82 100755
+--- a/imx/run.sh
++++ b/imx/run.sh
+@@ -3,6 +3,7 @@
+ # Start the isp_media_server in the configuration from user
+ # (c) NXP 2020-2022
+ # (c) Basler 2020
++# (c) Framos 2024
+ #
+ 
+ RUN_SCRIPT=`realpath -s $0`
+@@ -87,6 +88,43 @@ write_default_mode_files () {
+ 	echo "[mode.3]" >> DAA3840_MODES.txt
+ 	echo "xml = \"DAA3840_30MC_1080P-hdr.xml\"" >> DAA3840_MODES.txt
+ 	echo "dwe = \"dewarp_config/daA3840_30mc_1080P.json\"" >> DAA3840_MODES.txt
++
++	# IMX662 modes file
++	echo -n "" > IMX662_MODES.txt
++	echo "[mode.0]" >> IMX662_MODES.txt
++	echo "xml = \"IMX662_Basic_1920x1080.xml\"" >> IMX662_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json\"" >> IMX662_MODES.txt
++	echo "[mode.1]" >> IMX662_MODES.txt
++	echo "xml = \"IMX662_Basic_1280x720.xml\"" >> IMX662_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json\"" >> IMX662_MODES.txt
++	echo "[mode.2]" >> IMX662_MODES.txt
++	echo "xml = \"IMX662_Basic_960x540.xml\"" >> IMX662_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX662_Basic_960x540.json\"" >> IMX662_MODES.txt
++	echo "[mode.3]" >> IMX662_MODES.txt
++	echo "xml = \"IMX662_Basic_640x480.xml\"" >> IMX662_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX662_Basic_640x480.json\"" >> IMX662_MODES.txt
++	# IMX676 modes file
++	echo -n "" > IMX676_MODES.txt
++	echo "[mode.0]" >> IMX676_MODES.txt
++	echo "xml = \"IMX676_Basic_3536x3072.xml\"" >> IMX676_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json\"" >> IMX676_MODES.txt
++	echo "[mode.1]" >> IMX676_MODES.txt
++	echo "xml = \"IMX676_Basic_3536x2140.xml\"" >> IMX676_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json\"" >> IMX676_MODES.txt
++	echo "[mode.2]" >> IMX676_MODES.txt
++	echo "xml = \"IMX676_Basic_1776x1778.xml\"" >> IMX676_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json\"" >> IMX676_MODES.txt
++	echo "[mode.3]" >> IMX676_MODES.txt
++	echo "xml = \"IMX676_Basic_1760x1070.xml\"" >> IMX676_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json\"" >> IMX676_MODES.txt
++	# IMX678 modes file
++	echo -n "" > IMX678_MODES.txt
++	echo "[mode.0]" >> IMX678_MODES.txt
++	echo "xml = \"IMX678_Basic_3840x2160.xml\"" >> IMX678_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json\"" >> IMX678_MODES.txt
++	echo "[mode.1]" >> IMX678_MODES.txt
++	echo "xml = \"IMX678_Basic_1920x1080.xml\"" >> IMX678_MODES.txt
++	echo "dwe = \"dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json\"" >> IMX678_MODES.txt
+ }
+ 
+ # write the sensonr config file
+@@ -308,6 +346,70 @@ case "$ISP_CONFIG" in
+                          write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
+                          write_sensor_cfg_file "Sensor1_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
+                          ;;
++		imx662 )
++			MODULES_TO_REMOVE=("imx662" "${MODULES[@]}")
++			MODULES=(  "imx662" "${MODULES[@]}")
++			RUN_OPTION="CAMERA0"
++			CAM_NAME="imx662"
++			DRV_FILE="imx662.drv"
++			MODE_FILE="IMX662_MODES.txt"
++			MODE="0"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++		dual_imx662 )
++			MODULES_TO_REMOVE=("imx662" "${MODULES[@]}")
++			MODULES=("imx662" "${MODULES[@]}")
++			RUN_OPTION="DUAL_CAMERA"
++			CAM_NAME="imx662"
++			DRV_FILE="imx662.drv"
++			MODE_FILE="IMX662_MODES.txt"
++			MODE="0"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			write_sensor_cfg_file "Sensor1_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++		imx676_4k )
++			MODULES_TO_REMOVE=(  "imx676" "${MODULES[@]}")
++			MODULES=("imx676" "${MODULES[@]}")
++			RUN_OPTION="CAMERA0"
++			CAM_NAME="imx676"
++			DRV_FILE="imx676.drv"
++			MODE_FILE="IMX676_MODES.txt"
++			MODE="0"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++
++		dual_imx676_4k )
++			MODULES_TO_REMOVE=("imx676" "${MODULES[@]}")
++			MODULES=("imx676" "${MODULES[@]}")
++			RUN_OPTION="DUAL_CAMERA"
++			CAM_NAME="imx676"
++			DRV_FILE="imx676.drv"
++			MODE_FILE="IMX676_MODES.txt"
++			MODE="3"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			write_sensor_cfg_file "Sensor1_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++		imx678_4k )
++			MODULES_TO_REMOVE=("imx678" "${MODULES[@]}")
++			MODULES=("imx678" "${MODULES[@]}")
++			RUN_OPTION="CAMERA0"
++			CAM_NAME="imx678"
++			DRV_FILE="imx678.drv"
++			MODE_FILE="IMX678_MODES.txt"
++			MODE="0"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
++		dual_imx678_4k )
++			MODULES_TO_REMOVE=("imx678" "${MODULES[@]}")
++			MODULES=("imx678" "${MODULES[@]}")
++			RUN_OPTION="DUAL_CAMERA"
++			CAM_NAME="imx678"
++			DRV_FILE="imx678.drv"
++			MODE_FILE="IMX678_MODES.txt"
++			MODE="1"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			write_sensor_cfg_file "Sensor1_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
+ 		 *)
+ 			echo "ISP configuration \"$ISP_CONFIG\" unsupported."
+ 			echo -e "$USAGE" >&2
+diff --git a/imx/start_isp.sh b/imx/start_isp.sh
+index 22e7783..1282e31 100755
+--- a/imx/start_isp.sh
++++ b/imx/start_isp.sh
+@@ -1,15 +1,20 @@
+ #!/bin/sh
+ #
+ # Start the isp_media_server in the configuration for Basler daA3840-30mc
++# Also start the isp_media_server in the configuration for Framos IMX Sensors
+ #
+ # (c) Basler 2020
+ # (c) NXP 2020-2022
++# (c) Framos 2024
+ #
+ 
+ RUNTIME_DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+ NR_DEVICE_TREE_BASLER=$(grep basler-camera-vvcam `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
+ NR_DEVICE_TREE_OV5640=$(grep ov5640 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
+ NR_DEVICE_TREE_OS08A20=$(grep os08a20 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
++NR_DEVICE_TREE_IMX662=$(grep imx662 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
++NR_DEVICE_TREE_IMX676=$(grep imx676 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
++NR_DEVICE_TREE_IMX678=$(grep imx678 `find /sys/firmware/devicetree/base/soc@0/ -name compatible | grep i2c` -l | wc -l 2> /dev/null)
+ 
+ 
+ # check if the basler device has been enabled in the device tree
+@@ -69,8 +74,59 @@ elif [ $NR_DEVICE_TREE_OS08A20 -eq 2 ]; then
+ 	# Available configurations: dual_Os08a20_1080p60, dual_Os08a20_1080p30hdr
+ 	exec ./run.sh -c dual_os08a20_1080p60 -lm
+ 
++# check for imx662 devices
++elif [ $NR_DEVICE_TREE_IMX662 -eq 2 ]; then
++
++	echo "Starting isp_media_server for Dual IMX662"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c dual_imx662 -lm
++
++elif [ $NR_DEVICE_TREE_IMX662 -eq 1 ]; then
++
++	echo "Starting isp_media_server for IMX662"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c imx662 -lm
++
++# check for imx676 devices
++elif [ $NR_DEVICE_TREE_IMX676 -eq 2 ]; then
++
++	echo "Starting isp_media_server for Dual IMX676"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c dual_imx676_4k -lm
++	
++elif [ $NR_DEVICE_TREE_IMX676 -eq 1 ]; then
++
++	echo "Starting isp_media_server for IMX676"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c imx676_4k -lm
++
++# check for imx678 devices
++elif [ $NR_DEVICE_TREE_IMX678 -eq 2 ]; then
++
++	echo "Starting isp_media_server for Dual IMX678"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c dual_imx678_4k -lm
++	
++elif [ $NR_DEVICE_TREE_IMX678 -eq 1 ]; then
++
++	echo "Starting isp_media_server for IMX678"
++
++	cd $RUNTIME_DIR
++	
++	exec ./run.sh -c imx678_4k -lm
++
+ else
+ 	# no device tree found exit with code no device or address
+-	echo "No device tree found for Basler camera or os08a20, check dtb file!" >&2
++	echo "No device tree found for image sensors, check dtb file!" >&2
+ 	exit 0
+-fi
++fi
+\ No newline at end of file
+diff --git a/units/isi/CMakeLists.txt b/units/isi/CMakeLists.txt
+index 8cd95b5..d341936 100755
+--- a/units/isi/CMakeLists.txt
++++ b/units/isi/CMakeLists.txt
+@@ -76,7 +76,13 @@ add_subdirectory( drv/AR1335 )
+ ###add_subdirectory( drv/OV8810 )
+ #add_subdirectory( drv/OV14825 )
+ #add_subdirectory( drv/OV5640 )
++add_subdirectory( drv/imx662 )
++add_subdirectory( drv/imx676 )
++add_subdirectory( drv/imx678 )
+ else (GENERATE_PARTITION_BUILD)
++add_subdirectory( drv/imx662 )
++add_subdirectory( drv/imx676 )
++add_subdirectory( drv/imx678 )
+ add_subdirectory( drv/OS08a20 )
+ endif (GENERATE_PARTITION_BUILD)
+ 
+diff --git a/units/isi/drv/imx662/CMakeLists.txt b/units/isi/drv/imx662/CMakeLists.txt
+new file mode 100644
+index 0000000..5bc9d79
+--- /dev/null
++++ b/units/isi/drv/imx662/CMakeLists.txt
+@@ -0,0 +1,122 @@
++cmake_minimum_required(VERSION 2.6)
++
++# define module name & interface version
++set (module imx662)
++
++# define interface version
++set (${module}_INTERFACE_CURRENT  1)
++set (${module}_INTERFACE_REVISION 0)
++set (${module}_INTERFACE_AGE      0)
++
++# we want to compile all .c files as default
++file(GLOB libsources source/IMX662.c )
++
++# set public headers, these get installed
++file(GLOB pub_headers include/*.h)
++
++# define include paths
++include_directories(
++    include
++    include_priv
++    ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include
++    )
++
++# module specific defines
++###add_definitions(-Wno-error=unused-function)
++
++# add lib to build env
++#add_library(${module}_static STATIC ${libsources})
++add_library(${module}_shared SHARED ${libsources})
++
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES OUTPUT_NAME     ${module})
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES LINK_FLAGS      -static)
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES OUTPUT_NAME     ${module})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES LINK_FLAGS      -shared)
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES SOVERSION       ${${module}_INTERFACE_CURRENT})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES VERSION         ${${module}_INTERFACE_CURRENT}.${${module}_INTERFACE_REVISION}.${${module}_INTERFACE_AGE})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++# add convenience target: put sensor driver into the 'bin' output dir as well
++if ( NOT ANDROID )
++add_custom_target(${module}.drv
++                  ALL
++                  COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${module}.drv
++                  DEPENDS ${module}_shared
++                  COMMENT "Copying ${module} driver module"
++                  )
++endif()
++
++# define lib dependencies
++#target_link_libraries(${module}_static
++#                      ${platform_libs}
++#                      ${base_libs}
++#                      ${drv_libs}
++#                      isi_shared
++#                      )
++
++# add link libs, or dlopen failed on Android
++if (ANDROID)
++if (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${platform_libs}
++                      ${base_libs}
++                      ${drv_libs}
++                      isi_shared
++                      )
++else (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${android_partial_platform_libs}
++                      ${android_partial_base_libs}
++                      ${android_partial_drv_libs}
++                      isi_shared
++                      )
++add_library(PrebuiltLibs SHARED IMPORTED)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libhal.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libbufferpool.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libcameric_drv.so)
++target_link_libraries(${module}_shared PRIVATE PrebuiltLibs)
++endif (GENERATE_PARTITION_BUILD)
++endif (ANDROID)
++
++# define stuff to install
++#install(TARGETS ${module}_static
++#        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++#        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
++#        )
++
++install(TARGETS ${module}_shared
++        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        LIBRARY         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        )
++
++# install the sensor driver as well, but to 'bin' location!
++install(FILES       ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT}
++        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++        RENAME      ${module}.drv
++        )
++
++if( DEFINED APPSHELL_TOP_COMPILE)
++add_custom_target(copy_shell_libs_${module} ALL
++       COMMENT "##Copy libs to shell libs"
++       COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so ${CMAKE_HOME_DIRECTORY}/shell_libs/ispcore/${PLATFORM}/lib${module}.so
++       #COMMAND ${CMAKE_COMMAND} -E copy_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/${module} ${CMAKE_HOME_DIRECTORY}/shell_libs/include/units_headers/${module}
++)
++add_dependencies(copy_shell_libs_${module} ${module}_shared)
++endif( DEFINED APPSHELL_TOP_COMPILE)
++
++if (NOT GENERATE_PARTITION_BUILD)
++add_custom_target(${module}_create_isi_dir
++                  COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/isi
++                  COMMENT "Create isi dir for ${module}")
++add_dependencies(${module}_create_isi_dir ${module}_shared)
++endif (NOT GENERATE_PARTITION_BUILD)
++
++unset(HEADER_CP_VAR)
++# create common targets for this module
++include(${UNITS_TOP_DIRECTORY}/targets.cmake)
++
++# create calib data targets
++add_subdirectory(calib)
+\ No newline at end of file
+diff --git a/units/isi/drv/imx662/Sensor0_Entry.cfg b/units/isi/drv/imx662/Sensor0_Entry.cfg
+new file mode 100644
+index 0000000..81da8e0
+--- /dev/null
++++ b/units/isi/drv/imx662/Sensor0_Entry.cfg
+@@ -0,0 +1,15 @@
++name = "imx662"
++drv = "IMX662.drv"
++mode = 0
++[mode.0]
++xml = "IMX662_Basic_1920x1080.xml"
++dwe = "dewarp_config/sensor_dwe_IMX662_Basic_1920x1080.json"
++[mode.1]
++xml = "IMX662_Basic_1280x720.xml"
++dwe = "dewarp_config/sensor_dwe_IMX662_Basic_1280x720.json"
++[mode.2]
++xml = "IMX662_Basic_960x540.xml"
++dwe = "dewarp_config/sensor_dwe_IMX662_Basic_960x540.json"
++[mode.3]
++xml = "IMX662_Basic_640x480.xml"
++dwe = "dewarp_config/sensor_dwe_IMX662_Basic_640x480.json"
+\ No newline at end of file
+diff --git a/units/isi/drv/imx662/Sensor1_Entry.cfg b/units/isi/drv/imx662/Sensor1_Entry.cfg
+new file mode 100644
+index 0000000..575ae8f
+--- /dev/null
++++ b/units/isi/drv/imx662/Sensor1_Entry.cfg
+@@ -0,0 +1,15 @@
++name = "imx662"
++drv = "IMX662.drv"
++mode = 0
++[mode.0]
++xml = "IMX662.xml"
++dwe = "dewarp_config/sensor_dwe_imx662_1080p_config.json"
++[mode.1]
++xml = "IMX662_crop.xml"
++dwe = "dewarp_config/sensor_dwe_imx662_1080p_crop.json"
++[mode.2]
++xml = "IMX662_binning.xml"
++dwe = "dewarp_config/sensor_dwe_imx662_1080p_binning.json"
++[mode.3]
++xml = "IMX662_binning_crop.xml"
++dwe = "dewarp_config/sensor_dwe_imx662_1080p_binning_crop.json"
+\ No newline at end of file
+diff --git a/units/isi/drv/imx662/calib/CMakeLists.txt b/units/isi/drv/imx662/calib/CMakeLists.txt
+new file mode 100644
+index 0000000..b6a77aa
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/CMakeLists.txt
+@@ -0,0 +1,43 @@
++cmake_minimum_required(VERSION 2.6)
++
++# use upper level module name
++
++# get calib data filenames
++file(GLOB_RECURSE calib_files *.xml)
++list(SORT calib_files)
++
++# a nice helper function
++function(add_calib_target ${calib_file})
++    # get calib data file's base name
++    get_filename_component(base_name ${calib_file} NAME_WE)
++
++    # add target to put sensor driver calibration data file into the 'bin' output and create a similar named symlink to the driver as well
++    add_custom_target(${base_name}_calib
++                      ALL
++                      COMMAND ${CMAKE_COMMAND} -E copy ${calib_file} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.xml
++                      #COMMAND ${CMAKE_COMMAND} -E create_symlink ${module}.drv ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.drv
++                      DEPENDS ${calib_file}
++                      COMMENT "Configuring ${base_name} calibration database"
++                      )
++
++#    add_dependencies(${module}_static
++#                     ${base_name}_calib
++#                     )
++
++    add_dependencies(${module}_shared
++                     ${base_name}_calib
++                     )
++
++    # install the sensor driver config & similar named driver symlink as well, but to 'bin' location!
++    install(FILES       ${calib_file}
++            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++            RENAME      ${base_name}.xml
++            )
++    install(CODE "${CMAKE_COMMAND} -E create_symlink ${module}.drv ${CMAKE_INSTALL_PREFIX}/bin/${base_name}.drv")
++endfunction(add_calib_target)
++
++# loop over all calib data files
++foreach(calib_file ${calib_files})
++    add_calib_target(calib_file)
++endforeach(calib_file)
++
+diff --git a/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1280x720.xml b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1280x720.xml
+new file mode 100644
+index 0000000..6c5d803
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1280x720.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX662
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 31]">
++         Basic_1280x720
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1280]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 720]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 8]">
++                  1280x720
++               </name>
++               <resolution index="1" type="char" size="[1 8]">
++                  1280x720
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.377265 0.453448 0.16929]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.722429 0.0317105 0.690718 0.380478 -0.815881 0.4354]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.923942 -0.382533 -2.3857]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.0168334 0.00867816 0.00113847 -0.00520983 -0.0106308 -0.0151969 -0.0186654 -0.0209561 -0.0220965 -0.0219136 -0.0203486 -0.017276 -0.0126376 -0.00615952 0.00204326 0.021531]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.0068334 0.00132184 0.00886153 0.0152098 0.0206308 0.0251969 0.0286654 0.0309561 0.0320965 0.0319136 0.0303486 0.027276 0.0226376 0.0161595 0.00795674 -0.011531]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.181277 0.162752 0.145807 0.130081 0.116211 0.103703 0.0930213 0.084579 0.0781971 0.0742299 0.0728297 0.0743474 0.0790814 0.0875527 0.0999388 0.13674]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0187228 0.0372484 0.0541927 0.0699188 0.0837894 0.0962966 0.106979 0.115421 0.121803 0.12577 0.12717 0.125653 0.120919 0.112447 0.100061 0.063261]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.1291]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.94]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.5917]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [1655.86 1747.05 1747.05 3104.2994]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 229.9837]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0412262 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 8]">
++                        1280x720
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        1280x720_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.15015 1 1 3.4203]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-26.8287 -29.2466 -34.8069]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_105
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [367.579 -5.33398 -5.33398 1266.0696]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 108.5703]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.18244 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 8]">
++                        1280x720
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1280x720_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.95205 1 1 1.621]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-27.6273 -28.2602 -32.482]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [557.808 359.254 359.254 1475.5552]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 132.588]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0346831 -0.029875]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 8]">
++                        1280x720
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1280x720_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.40512 1 1 2.6572]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-29.618 -33.7968 -31.8702]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               1280x720_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [66 76 78 78 84 84 86 88]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [43 46 44 45 46 46 46 44]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1280x720_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [66 76 78 78 84 84 86 88]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [43 46 44 45 46 46 46 44]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1280x720_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [66 76 78 78 84 84 86 88]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [43 46 44 45 46 46 46 44]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               1280x720_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [66 76 78 78 84 84 86 88]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [43 46 44 45 46 46 46 44]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_105
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 105]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-26.8287 -29.2466 -34.8069]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.15015 1 1 3.4203]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-27.6273 -28.2602 -32.482]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.95205 1 1 1.621]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-29.618 -33.7968 -31.8702]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.40512 1 1 2.6572]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.08814 -0.844023 -0.237191 -0.460044 1.60443 -0.0996407 0.00434868 -0.488471 1.5272]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.3746 -33.1455 -33.8914]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.68999 1 1 2.8635]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 15]">
++                  1280x720_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 15]">
++                  1280x720_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 15]">
++                  1280x720_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 8]">
++               1280x720
++            </name>
++            <resolution index="1" type="char" size="[1 8]">
++               1280x720
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1920x1080.xml b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1920x1080.xml
+new file mode 100644
+index 0000000..271ab35
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_1920x1080.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX662
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 32]">
++         Basic_1920x1080
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1920]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 1080]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  1920x1080
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  1920x1080
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.377265 0.453448 0.16929]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.722429 0.0317105 0.690718 0.380478 -0.815881 0.4354]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.923942 -0.382533 -2.3857]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.0168334 0.00867816 0.00113847 -0.00520983 -0.0106308 -0.0151969 -0.0186654 -0.0209561 -0.0220965 -0.0219136 -0.0203486 -0.017276 -0.0126376 -0.00615952 0.00204326 0.021531]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.0068334 0.00132184 0.00886153 0.0152098 0.0206308 0.0251969 0.0286654 0.0309561 0.0320965 0.0319136 0.0303486 0.027276 0.0226376 0.0161595 0.00795674 -0.011531]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.181277 0.162752 0.145807 0.130081 0.116211 0.103703 0.0930213 0.084579 0.0781971 0.0742299 0.0728297 0.0743474 0.0790814 0.0875527 0.0999388 0.13674]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0187228 0.0372484 0.0541927 0.0699188 0.0837894 0.0962966 0.106979 0.115421 0.121803 0.12577 0.12717 0.125653 0.120919 0.112447 0.100061 0.063261]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.1291]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.94]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.5917]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [1655.86 1747.05 1747.05 3104.2994]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 229.9837]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0412262 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1920x1080_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.15015 1 1 3.4203]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-26.8287 -29.2466 -34.8069]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_105
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [367.579 -5.33398 -5.33398 1266.0696]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 108.5703]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.18244 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1920x1080_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.95205 1 1 1.621]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-27.6273 -28.2602 -32.482]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [557.808 359.254 359.254 1475.5552]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 132.588]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0346831 -0.029875]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1920x1080_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.40512 1 1 2.6572]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-29.618 -33.7968 -31.8702]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1920x1080_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [75 93 104 114 130 141 147 156]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [56 63 64 68 72 72 73 72]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1920x1080_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [75 93 104 114 130 141 147 156]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [56 63 64 68 72 72 73 72]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1920x1080_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [75 93 104 114 130 141 147 156]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [56 63 64 68 72 72 73 72]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1920x1080_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [75 93 104 114 130 141 147 156]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [56 63 64 68 72 72 73 72]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_105
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 105]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-26.8287 -29.2466 -34.8069]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.15015 1 1 3.4203]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-27.6273 -28.2602 -32.482]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.95205 1 1 1.621]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-29.618 -33.7968 -31.8702]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.40512 1 1 2.6572]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.08814 -0.844023 -0.237191 -0.460044 1.60443 -0.0996407 0.00434868 -0.488471 1.5272]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.3746 -33.1455 -33.8914]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.68999 1 1 2.8635]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_640x480.xml b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_640x480.xml
+new file mode 100644
+index 0000000..a14bb39
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_640x480.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX662
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 30]">
++         Basic_640x480
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 640]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 480]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 7]">
++                  640x480
++               </name>
++               <resolution index="1" type="char" size="[1 7]">
++                  640x480
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.377265 0.453448 0.16929]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.722429 0.0317105 0.690718 0.380478 -0.815881 0.4354]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.923942 -0.382533 -2.3857]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.0168334 0.00867816 0.00113847 -0.00520983 -0.0106308 -0.0151969 -0.0186654 -0.0209561 -0.0220965 -0.0219136 -0.0203486 -0.017276 -0.0126376 -0.00615952 0.00204326 0.021531]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.0068334 0.00132184 0.00886153 0.0152098 0.0206308 0.0251969 0.0286654 0.0309561 0.0320965 0.0319136 0.0303486 0.027276 0.0226376 0.0161595 0.00795674 -0.011531]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.181277 0.162752 0.145807 0.130081 0.116211 0.103703 0.0930213 0.084579 0.0781971 0.0742299 0.0728297 0.0743474 0.0790814 0.0875527 0.0999388 0.13674]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0187228 0.0372484 0.0541927 0.0699188 0.0837894 0.0962966 0.106979 0.115421 0.121803 0.12577 0.12717 0.125653 0.120919 0.112447 0.100061 0.063261]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.1291]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.94]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.5917]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [1655.86 1747.05 1747.05 3104.2994]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 229.9837]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0412262 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        640x480
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 13]">
++                        640x480_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.15015 1 1 3.4203]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-26.8287 -29.2466 -34.8069]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_105
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [367.579 -5.33398 -5.33398 1266.0696]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 108.5703]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.18244 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        640x480
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        640x480_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.95205 1 1 1.621]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-27.6273 -28.2602 -32.482]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [557.808 359.254 359.254 1475.5552]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 132.588]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0346831 -0.029875]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        640x480
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        640x480_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.40512 1 1 2.6572]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-29.618 -33.7968 -31.8702]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 13]">
++               640x480_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [41 38 39 41 37 43 41 40]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [29 31 30 30 29 31 30 30]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               640x480_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [41 38 39 41 37 43 41 40]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [29 31 30 30 29 31 30 30]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               640x480_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [41 38 39 41 37 43 41 40]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [29 31 30 30 29 31 30 30]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 13]">
++               640x480_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [41 38 39 41 37 43 41 40]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [29 31 30 30 29 31 30 30]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_105
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 105]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-26.8287 -29.2466 -34.8069]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.15015 1 1 3.4203]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-27.6273 -28.2602 -32.482]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.95205 1 1 1.621]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-29.618 -33.7968 -31.8702]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.40512 1 1 2.6572]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.08814 -0.844023 -0.237191 -0.460044 1.60443 -0.0996407 0.00434868 -0.488471 1.5272]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.3746 -33.1455 -33.8914]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.68999 1 1 2.8635]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  640x480_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  640x480_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  640x480_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               640x480
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               640x480
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_960x540.xml b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_960x540.xml
+new file mode 100644
+index 0000000..0ff0f4d
+--- /dev/null
++++ b/units/isi/drv/imx662/calib/IMX662/IMX662_Basic_960x540.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX662
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 30]">
++         Basic_960x540
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 960]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 540]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 7]">
++                  960x540
++               </name>
++               <resolution index="1" type="char" size="[1 7]">
++                  960x540
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.377265 0.453448 0.16929]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.722429 0.0317105 0.690718 0.380478 -0.815881 0.4354]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.923942 -0.382533 -2.3857]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.0168334 0.00867816 0.00113847 -0.00520983 -0.0106308 -0.0151969 -0.0186654 -0.0209561 -0.0220965 -0.0219136 -0.0203486 -0.017276 -0.0126376 -0.00615952 0.00204326 0.021531]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.12914 1.18053 1.23192 1.28331 1.33471 1.3861 1.43749 1.48889 1.54028 1.59167 1.64307 1.69446 1.74585 1.79724 1.84864 1.9]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.0068334 0.00132184 0.00886153 0.0152098 0.0206308 0.0251969 0.0286654 0.0309561 0.0320965 0.0319136 0.0303486 0.027276 0.0226376 0.0161595 0.00795674 -0.011531]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.181277 0.162752 0.145807 0.130081 0.116211 0.103703 0.0930213 0.084579 0.0781971 0.0742299 0.0728297 0.0743474 0.0790814 0.0875527 0.0999388 0.13674]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.876002 0.952004 1.02801 1.10401 1.18001 1.25601 1.33201 1.40802 1.48402 1.56002 1.63602 1.71202 1.78803 1.86403 1.94]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0187228 0.0372484 0.0541927 0.0699188 0.0837894 0.0962966 0.106979 0.115421 0.121803 0.12577 0.12717 0.125653 0.120919 0.112447 0.100061 0.063261]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.1291]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.94]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.5917]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [1655.86 1747.05 1747.05 3104.2994]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 229.9837]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0412262 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        960x540
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 12]">
++                        960x540_A_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.15015 1 1 3.4203]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-26.8287 -29.2466 -34.8069]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_105
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [367.579 -5.33398 -5.33398 1266.0696]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 108.5703]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.18244 -0.012786]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        960x540
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        960x540_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.95205 1 1 1.621]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-27.6273 -28.2602 -32.482]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [557.808 359.254 359.254 1475.5552]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 132.588]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0346831 -0.029875]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 7]">
++                        960x540
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 14]">
++                        960x540_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.40512 1 1 2.6572]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-29.618 -33.7968 -31.8702]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_107
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 12]">
++               960x540_A_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [60 60 60 60 60 60 60 60]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [34 34 34 34 34 34 34 32]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               960x540_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [60 60 60 60 60 60 60 60]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [34 34 34 34 34 34 34 32]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 14]">
++               960x540_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [60 60 60 60 60 60 60 60]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [34 34 34 34 34 34 34 32]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 13]">
++               960x540_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [60 60 60 60 60 60 60 60]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [34 34 34 34 34 34 34 32]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_105
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 105]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.43277 0.0249912 -0.444464 -0.538697 1.76311 -0.191273 0.0797606 -0.852136 1.7809]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-26.8287 -29.2466 -34.8069]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.15015 1 1 3.4203]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.71817 -0.427291 -0.284132 -0.336663 1.6632 -0.303839 -0.00780319 -0.414388 1.4325]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-27.6273 -28.2602 -32.482]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.95205 1 1 1.621]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.62374 -0.315443 -0.30106 -0.493166 1.71976 -0.176214 0.014794 -0.540407 1.5682]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-29.618 -33.7968 -31.8702]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.40512 1 1 2.6572]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_107
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 107]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.08814 -0.844023 -0.237191 -0.460044 1.60443 -0.0996407 0.00434868 -0.488471 1.5272]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.3746 -33.1455 -33.8914]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.68999 1 1 2.8635]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  960x540_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  960x540_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 14]">
++                  960x540_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               960x540
++            </name>
++            <resolution index="1" type="char" size="[1 7]">
++               960x540
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx662/source/IMX662.c b/units/isi/drv/imx662/source/IMX662.c
+new file mode 100644
+index 0000000..418bfda
+--- /dev/null
++++ b/units/isi/drv/imx662/source/IMX662.c
+@@ -0,0 +1,1268 @@
++/******************************************************************************\
++|* Copyright (c) 2020 by VeriSilicon Holdings Co., Ltd. ("VeriSilicon")       *|
++|* All Rights Reserved.                                                       *|
++|*                                                                            *|
++|* The material in this file is confidential and contains trade secrets of    *|
++|* of VeriSilicon.  This is proprietary information owned or licensed by      *|
++|* VeriSilicon.  No part of this work may be disclosed, reproduced, copied,   *|
++|* transmitted, or used in any way for any purpose, without the express       *|
++|* written permission of VeriSilicon.                                         *|
++|*                                                                            *|
++\******************************************************************************/
++
++#include <ebase/types.h>
++#include <ebase/trace.h>
++#include <ebase/builtins.h>
++#include <common/return_codes.h>
++#include <common/misc.h>
++#include <sys/ioctl.h>
++#include <fcntl.h>
++#include "isi.h"
++#include "isi_iss.h"
++#include "isi_priv.h"
++#include "vvsensor.h"
++
++CREATE_TRACER( IMX662_INFO , "IMX662: ", INFO,    1);
++CREATE_TRACER( IMX662_WARN , "IMX662: ", WARNING, 1);
++CREATE_TRACER( IMX662_ERROR, "IMX662: ", ERROR,   1);
++
++#ifdef SUBDEV_V4L2
++#include <sys/ioctl.h>
++#include <sys/mman.h>
++#include <fcntl.h>
++#include <linux/videodev2.h>
++#include <linux/v4l2-subdev.h>
++//#undef TRACE
++//#define TRACE(x, ...)
++#endif
++
++static const char SensorName[16] = "imx662";
++
++typedef struct IMX662_Context_s
++{
++    IsiSensorContext_t  IsiCtx;
++    struct vvcam_mode_info_s CurMode;
++    IsiSensorAeInfo_t AeInfo;
++    IsiSensorIntTime_t IntTime;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    IsiSensorGain_t SensorGain;
++    uint32_t minAfps;
++    uint64_t AEStartExposure;
++} IMX662_Context_t;
++
++static RESULT IMX662_IsiSensorSetPowerIss(IsiSensorHandle_t handle, bool_t on)
++{
++    int ret = 0;
++
++    TRACE( IMX662_INFO, "%s: (enter)\n", __func__);
++    TRACE( IMX662_INFO, "%s: set power %d\n", __func__,on);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    int32_t power = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_POWER, &power);
++    if (ret != 0){
++        TRACE(IMX662_ERROR, "%s set power %d error\n", __func__,power);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorGetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (!pclk)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CLK, pclk);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s get clock error\n", __func__);
++        return RET_FAILURE;
++    } 
++    
++    TRACE( IMX662_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++    TRACE( IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorSetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pclk == NULL)
++        return RET_NULL_POINTER;
++    
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_CLK, &pclk);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX662_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++
++    TRACE( IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiResetSensorIss(IsiSensorHandle_t handle)
++{
++    int ret = 0;
++
++    TRACE( IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_RESET, NULL);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s set reset error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiRegisterReadIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        uint32_t * pValue)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_READ_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: read sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    *pValue = sccb_data.data;
++
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiRegisterWriteIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        const uint32_t value)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = value;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_WRITE_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: write sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_UpdateIsiAEInfo(IsiSensorHandle_t handle)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    IsiSensorAeInfo_t *pAeInfo = &pIMX662Ctx->AeInfo;
++    pAeInfo->oneLineExpTime = pIMX662Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++
++    if (pIMX662Ctx->CurMode.hdr_mode == SENSOR_MODE_LINEAR) {
++        pAeInfo->maxIntTime.linearInt =
++            pIMX662Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->minIntTime.linearInt =
++            pIMX662Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->maxAGain.linearGainParas = pIMX662Ctx->CurMode.ae_info.max_again;
++        pAeInfo->minAGain.linearGainParas = pIMX662Ctx->CurMode.ae_info.min_again;
++        pAeInfo->maxDGain.linearGainParas = pIMX662Ctx->CurMode.ae_info.max_dgain;
++        pAeInfo->minDGain.linearGainParas = pIMX662Ctx->CurMode.ae_info.min_dgain;
++    } else {
++        switch (pIMX662Ctx->CurMode.stitching_mode) {
++            case SENSOR_STITCHING_DUAL_DCG:
++            case SENSOR_STITCHING_3DOL:
++            case SENSOR_STITCHING_LINEBYLINE:
++                pAeInfo->maxIntTime.triInt.triSIntTime =
++                    pIMX662Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triSIntTime =
++                    pIMX662Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                
++                pAeInfo->maxIntTime.triInt.triIntTime =
++                    pIMX662Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triIntTime =
++                    pIMX662Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX662Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG) {
++                    pAeInfo->maxIntTime.triInt.triLIntTime = pAeInfo->maxIntTime.triInt.triIntTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime = pAeInfo->minIntTime.triInt.triIntTime;
++                } else {
++                    pAeInfo->maxIntTime.triInt.triLIntTime =
++                        pIMX662Ctx->CurMode.ae_info.max_longintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime =
++                        pIMX662Ctx->CurMode.ae_info.min_longintegration_line * pAeInfo->oneLineExpTime;
++                }
++
++                pAeInfo->maxAGain.triGainParas.triSGain = pIMX662Ctx->CurMode.ae_info.max_short_again;
++                pAeInfo->minAGain.triGainParas.triSGain = pIMX662Ctx->CurMode.ae_info.min_short_again;
++                pAeInfo->maxDGain.triGainParas.triSGain = pIMX662Ctx->CurMode.ae_info.max_short_dgain;
++                pAeInfo->minDGain.triGainParas.triSGain = pIMX662Ctx->CurMode.ae_info.min_short_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triGain = pIMX662Ctx->CurMode.ae_info.max_again;
++                pAeInfo->minAGain.triGainParas.triGain = pIMX662Ctx->CurMode.ae_info.min_again;
++                pAeInfo->maxDGain.triGainParas.triGain = pIMX662Ctx->CurMode.ae_info.max_dgain;
++                pAeInfo->minDGain.triGainParas.triGain = pIMX662Ctx->CurMode.ae_info.min_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triLGain = pIMX662Ctx->CurMode.ae_info.max_long_again;
++                pAeInfo->minAGain.triGainParas.triLGain = pIMX662Ctx->CurMode.ae_info.min_long_again;
++                pAeInfo->maxDGain.triGainParas.triLGain = pIMX662Ctx->CurMode.ae_info.max_long_dgain;
++                pAeInfo->minDGain.triGainParas.triLGain = pIMX662Ctx->CurMode.ae_info.min_long_dgain;
++                break;
++            case SENSOR_STITCHING_DUAL_DCG_NOWAIT:
++            case SENSOR_STITCHING_16BIT_COMPRESS:
++            case SENSOR_STITCHING_L_AND_S:
++            case SENSOR_STITCHING_2DOL:
++                pAeInfo->maxIntTime.dualInt.dualIntTime =
++                    pIMX662Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.dualInt.dualIntTime =
++                    pIMX662Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX662Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime = pAeInfo->maxIntTime.dualInt.dualIntTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime = pAeInfo->minIntTime.dualInt.dualIntTime;
++                } else {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime =
++                        pIMX662Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime =
++                        pIMX662Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                }
++                
++                if (pIMX662Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.min_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.max_long_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.min_long_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.max_long_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.min_long_dgain;
++                } else {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.max_short_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.min_short_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.max_short_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX662Ctx->CurMode.ae_info.min_short_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX662Ctx->CurMode.ae_info.min_dgain;
++                }
++                
++                break;
++            default:
++                break;
++        }
++    }
++    pAeInfo->gainStep = pIMX662Ctx->CurMode.ae_info.gain_step;
++    pAeInfo->currFps  = pIMX662Ctx->CurMode.ae_info.cur_fps;
++    pAeInfo->maxFps   = pIMX662Ctx->CurMode.ae_info.max_fps;
++    pAeInfo->minFps   = pIMX662Ctx->CurMode.ae_info.min_fps;
++    pAeInfo->minAfps  = pIMX662Ctx->CurMode.ae_info.min_afps;
++    pAeInfo->hdrRatio[0] = pIMX662Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s;
++    pAeInfo->hdrRatio[1] = pIMX662Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs;
++
++    pAeInfo->intUpdateDlyFrm = pIMX662Ctx->CurMode.ae_info.int_update_delay_frm;
++    pAeInfo->gainUpdateDlyFrm = pIMX662Ctx->CurMode.ae_info.gain_update_delay_frm;
++
++    if (pIMX662Ctx->minAfps != 0) {
++        pAeInfo->minAfps = pIMX662Ctx->minAfps;
++    } 
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    memcpy(pMode, &pIMX662Ctx->CurMode, sizeof(IsiSensorMode_t));
++
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    struct vvcam_mode_info_s sensor_mode;
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    sensor_mode.index = pMode->index;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s set sensor mode failed", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX662Ctx->CurMode, &sensor_mode, sizeof(struct vvcam_mode_info_s));
++    IMX662_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorSetStreamingIss(IsiSensorHandle_t handle,
++                                              bool_t on)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    uint32_t status = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_STREAM, &status);
++    if (ret != 0){
++        TRACE(IMX662_ERROR, "%s set sensor stream %d error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: set streaming %d\n", __func__, on);
++    TRACE(IMX662_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiCreateSensorIss(IsiSensorInstanceConfig_t * pConfig)
++{
++    RESULT result = RET_SUCCESS;
++    IMX662_Context_t *pIMX662Ctx;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    if (!pConfig || !pConfig->pSensor || !pConfig->HalHandle)
++        return RET_NULL_POINTER;
++
++    pIMX662Ctx = (IMX662_Context_t *) malloc(sizeof(IMX662_Context_t));
++    if (!pIMX662Ctx)
++        return RET_OUTOFMEM;
++
++    memset(pIMX662Ctx, 0, sizeof(IMX662_Context_t));
++    pIMX662Ctx->IsiCtx.HalHandle = pConfig->HalHandle;
++    pIMX662Ctx->IsiCtx.pSensor   = pConfig->pSensor;
++    pConfig->hSensor = (IsiSensorHandle_t) pIMX662Ctx;
++
++    result = IMX662_IsiSensorSetPowerIss(pIMX662Ctx, BOOL_TRUE);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s set power error\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    result = IMX662_IsiSensorGetClkIss(pIMX662Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s get clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    clk.status = 1;
++    result = IMX662_IsiSensorSetClkIss(pIMX662Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    result = IMX662_IsiResetSensorIss(pIMX662Ctx);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s retset sensor error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    IsiSensorMode_t SensorMode;
++    SensorMode.index = pConfig->SensorModeIndex;
++    result = IMX662_IsiSetSensorModeIss(pIMX662Ctx, &SensorMode);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX662_IsiReleaseSensorIss(IsiSensorHandle_t handle)
++{
++    TRACE(IMX662_INFO, "%s (enter) \n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    if (pIMX662Ctx == NULL)
++        return (RET_WRONG_HANDLE);
++
++    IMX662_IsiSensorSetStreamingIss(pIMX662Ctx, BOOL_FALSE);
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    IMX662_IsiSensorGetClkIss(pIMX662Ctx, &clk);
++    clk.status = 0;
++    IMX662_IsiSensorSetClkIss(pIMX662Ctx, &clk);
++    IMX662_IsiSensorSetPowerIss(pIMX662Ctx, BOOL_FALSE);
++    free(pIMX662Ctx);
++    pIMX662Ctx = NULL;
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiHalQuerySensorIss(HalHandle_t HalHandle,
++                                          IsiSensorModeInfoArray_t *pSensorMode)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter) \n", __func__);
++
++    if (HalHandle == NULL || pSensorMode == NULL)
++        return RET_NULL_POINTER;
++
++    HalContext_t *pHalCtx = (HalContext_t *)HalHandle;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_QUERY, pSensorMode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiQuerySensorIss(IsiSensorHandle_t handle,
++                                       IsiSensorModeInfoArray_t *pSensorMode)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX662_INFO, "%s (enter) \n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    result = IMX662_IsiHalQuerySensorIss(pIMX662Ctx->IsiCtx.HalHandle,
++                                         pSensorMode);
++    if (result != RET_SUCCESS)
++        TRACE(IMX662_ERROR, "%s: query sensor mode info error!\n", __func__);
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX662_IsiGetCapsIss(IsiSensorHandle_t handle,
++                                   IsiSensorCaps_t * pIsiSensorCaps)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX662_INFO, "%s (enter) \n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    IsiSensorModeInfoArray_t SensorModeInfo;
++    memset(&SensorModeInfo, 0, sizeof(IsiSensorModeInfoArray_t));
++    result = IMX662_IsiQuerySensorIss(handle, &SensorModeInfo);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    pIsiSensorCaps->FieldSelection    = ISI_FIELDSEL_BOTH;
++    pIsiSensorCaps->YCSequence        = ISI_YCSEQ_YCBYCR;
++    pIsiSensorCaps->Conv422           = ISI_CONV422_NOCOSITED;
++    pIsiSensorCaps->HPol              = ISI_HPOL_REFPOS;
++    pIsiSensorCaps->VPol              = ISI_VPOL_NEG;
++    pIsiSensorCaps->Edge              = ISI_EDGE_RISING;
++    pIsiSensorCaps->supportModeNum    = SensorModeInfo.count;
++    pIsiSensorCaps->currentMode       = pIMX662Ctx->CurMode.index;
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX662_IsiSetupSensorIss(IsiSensorHandle_t handle,
++                                       const IsiSensorCaps_t *pIsiSensorCaps )
++{
++    int ret = 0;
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    if (pIsiSensorCaps->currentMode != pIMX662Ctx->CurMode.index) {
++        IsiSensorMode_t SensorMode;
++        memset(&SensorMode, 0, sizeof(IsiSensorMode_t));
++        SensorMode.index = pIsiSensorCaps->currentMode;
++        result = IMX662_IsiSetSensorModeIss(handle, &SensorMode);
++        if (result != RET_SUCCESS) {
++            TRACE(IMX662_ERROR, "%s:set sensor mode %d failed!\n",
++                  __func__, SensorMode.index);
++            return result;
++        }
++    }
++
++#ifdef SUBDEV_V4L2
++    struct v4l2_subdev_format format;
++    memset(&format, 0, sizeof(struct v4l2_subdev_format));
++    format.format.width  = pIMX662Ctx->CurMode.size.bounds_width;
++    format.format.height = pIMX662Ctx->CurMode.size.bounds_height;
++    format.which = V4L2_SUBDEV_FORMAT_ACTIVE;
++    format.pad = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VIDIOC_SUBDEV_S_FMT, &format);
++    if (ret != 0){
++        TRACE(IMX662_ERROR, "%s: sensor set format error!\n", __func__);
++        return RET_FAILURE;
++    }
++#else
++    ret = ioctrl(pHalCtx->sensor_fd, VVSENSORIOC_S_INIT, NULL);
++    if (ret != 0){
++        TRACE(IMX662_ERROR, "%s: sensor init error!\n", __func__);
++        return RET_FAILURE;
++    }
++#endif
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetSensorRevisionIss(IsiSensorHandle_t handle, uint32_t *pValue)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pValue == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CHIP_ID, pValue);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: get chip id error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiCheckSensorConnectionIss(IsiSensorHandle_t handle)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    uint32_t ChipId = 0;
++    result = IMX662_IsiGetSensorRevisionIss(handle, &ChipId);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX662_ERROR, "%s:get sensor chip id error!\n",__func__);
++        return RET_FAILURE;
++    }
++
++    if (ChipId != 662) {
++        TRACE(IMX662_ERROR,
++            "%s:ChipID=662,while read sensor Id=0x%x error!\n",
++             __func__, ChipId);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetAeInfoIss(IsiSensorHandle_t handle,
++                                     IsiSensorAeInfo_t *pAeInfo)
++{
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    if (pAeInfo == NULL)
++        return RET_NULL_POINTER;
++
++    memcpy(pAeInfo, &pIMX662Ctx->AeInfo, sizeof(IsiSensorAeInfo_t));
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetHdrRatioIss(IsiSensorHandle_t handle,
++                                       uint8_t hdrRatioNum,
++                                       uint32_t HdrRatio[])
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    struct sensor_hdr_artio_s hdr_ratio;
++    if (hdrRatioNum == 2) {
++        hdr_ratio.ratio_s_vs = HdrRatio[1];
++        hdr_ratio.ratio_l_s = HdrRatio[0];
++    }else {
++        hdr_ratio.ratio_s_vs = HdrRatio[0];
++        hdr_ratio.ratio_l_s = 0;
++    }
++
++    if (hdr_ratio.ratio_s_vs == pIMX662Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs &&
++        hdr_ratio.ratio_l_s == pIMX662Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s)
++        return RET_SUCCESS;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_HDR_RADIO, &hdr_ratio);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR,"%s: set hdr ratio error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s sensor_mode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR,"%s: get mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memcpy(&pIMX662Ctx->CurMode, &sensor_mode, sizeof (struct vvcam_mode_info_s));
++    IMX662_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    memcpy(pIntegrationTime, &pIMX662Ctx->IntTime, sizeof(IsiSensorIntTime_t));
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++
++}
++
++static RESULT IMX662_IsiSetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    int ret = 0;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    uint32_t oneLineTime;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++    printf("\n\nAAAAAAAAAAAAAAA %u\n\n", pIntegrationTime->IntegrationTime.linearInt);
++    if (pIntegrationTime == NULL)
++        return RET_NULL_POINTER;
++
++    oneLineTime =  pIMX662Ctx->AeInfo.oneLineExpTime;
++    pIMX662Ctx->IntTime.expoFrmType = pIntegrationTime->expoFrmType;
++
++    switch (pIntegrationTime->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            IntLine = pIntegrationTime->IntegrationTime.linearInt;
++            if (IntLine != pIMX662Ctx->IntLine) {
++                printf("\n\ngoing into S_EXP ioctl %u\n\n", IntLine);
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor linear exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++               pIMX662Ctx->IntLine = IntLine;
++            }
++            TRACE(IMX662_INFO, "%s set linear exp %d \n", __func__,IntLine);
++            pIMX662Ctx->IntTime.IntegrationTime.linearInt =  IntLine * oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            IntLine = pIntegrationTime->IntegrationTime.dualInt.dualIntTime;
++            if (IntLine != pIMX662Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor dual exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX662Ctx->IntLine = IntLine;
++            }
++
++            if (pIMX662Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                ShortIntLine = pIntegrationTime->IntegrationTime.dualInt.dualSIntTime;
++                if (ShortIntLine != pIMX662Ctx->ShortIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX662_ERROR,"%s:set sensor dual vsexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX662Ctx->ShortIntLine = ShortIntLine;
++                }
++            } else {
++                ShortIntLine = IntLine;
++                pIMX662Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX662_INFO, "%s set dual exp %d short_exp %d\n", __func__, IntLine, ShortIntLine);
++            pIMX662Ctx->IntTime.IntegrationTime.dualInt.dualIntTime  = IntLine + oneLineTime;
++            pIMX662Ctx->IntTime.IntegrationTime.dualInt.dualSIntTime = ShortIntLine + oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            if (pIMX662Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triLIntTime;
++                if (LongIntLine != pIMX662Ctx->LongIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_EXP, &LongIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX662_ERROR,"%s:set sensor tri lexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX662Ctx->LongIntLine = LongIntLine;
++                }
++            } else {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++                pIMX662Ctx->LongIntLine = LongIntLine;
++            }
++
++            IntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++            if (IntLine != pIMX662Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX662Ctx->IntLine = IntLine;
++            }
++            
++            ShortIntLine = pIntegrationTime->IntegrationTime.triInt.triSIntTime;
++            if (ShortIntLine != pIMX662Ctx->ShortIntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri vsexp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX662Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX662_INFO, "%s set tri long exp %d exp %d short_exp %d\n", __func__, LongIntLine, IntLine, ShortIntLine);
++            pIMX662Ctx->IntTime.IntegrationTime.triInt.triLIntTime = LongIntLine + oneLineTime;
++            pIMX662Ctx->IntTime.IntegrationTime.triInt.triIntTime = IntLine + oneLineTime;
++            pIMX662Ctx->IntTime.IntegrationTime.triInt.triSIntTime = ShortIntLine + oneLineTime;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++    
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++    memcpy(pGain, &pIMX662Ctx->SensorGain, sizeof(IsiSensorGain_t));
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    int ret = 0;
++    uint32_t LongGain;
++    uint32_t Gain;
++    uint32_t ShortGain;
++
++    TRACE(IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++
++    pIMX662Ctx->SensorGain.expoFrmType = pGain->expoFrmType;
++    switch (pGain->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            Gain = pGain->gain.linearGainParas;
++            if (pIMX662Ctx->SensorGain.gain.linearGainParas != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor linear gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            pIMX662Ctx->SensorGain.gain.linearGainParas = pGain->gain.linearGainParas;
++            TRACE(IMX662_INFO, "%s set linear gain %d\n", __func__,pGain->gain.linearGainParas);
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            Gain = pGain->gain.dualGainParas.dualGain;
++            if (pIMX662Ctx->SensorGain.gain.dualGainParas.dualGain != Gain) {
++                if (pIMX662Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &Gain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor dual gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.dualGainParas.dualSGain;
++            if (pIMX662Ctx->SensorGain.gain.dualGainParas.dualSGain != ShortGain) {
++                if (pIMX662Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &ShortGain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor dual vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX662_INFO,"%s:set gain%d short gain %d!\n", __func__,Gain,ShortGain);
++            pIMX662Ctx->SensorGain.gain.dualGainParas.dualGain = Gain;
++            pIMX662Ctx->SensorGain.gain.dualGainParas.dualSGain = ShortGain;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            LongGain = pGain->gain.triGainParas.triLGain;
++            if (pIMX662Ctx->SensorGain.gain.triGainParas.triLGain != LongGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &LongGain);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            Gain = pGain->gain.triGainParas.triGain;
++            if (pIMX662Ctx->SensorGain.gain.triGainParas.triGain != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.triGainParas.triSGain;
++            if (pIMX662Ctx->SensorGain.gain.triGainParas.triSGain != ShortGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                if (ret != 0) {
++                    TRACE(IMX662_ERROR,"%s:set sensor tri vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX662_INFO,"%s:set long gain %d gain%d short gain %d!\n", __func__, LongGain, Gain, ShortGain);
++            pIMX662Ctx->SensorGain.gain.triGainParas.triLGain = LongGain;
++            pIMX662Ctx->SensorGain.gain.triGainParas.triGain = Gain;
++            pIMX662Ctx->SensorGain.gain.triGainParas.triSGain = ShortGain;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++
++    TRACE(IMX662_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++
++static RESULT IMX662_IsiGetSensorFpsIss(IsiSensorHandle_t handle, uint32_t * pfps)
++{
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    if (pfps == NULL)
++        return RET_NULL_POINTER;
++
++    *pfps = pIMX662Ctx->CurMode.ae_info.cur_fps;
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetSensorFpsIss(IsiSensorHandle_t handle, uint32_t fps)
++{
++    int ret = 0;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_FPS, &fps);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR,"%s:set sensor fps error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s SensorMode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &SensorMode);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR,"%s:get sensor mode error!\n", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX662Ctx->CurMode, &SensorMode, sizeof(struct vvcam_mode_info_s));
++    IMX662_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++static RESULT IMX662_IsiSetSensorAfpsLimitsIss(IsiSensorHandle_t handle, uint32_t minAfps)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    if ((minAfps > pIMX662Ctx->CurMode.ae_info.max_fps) ||
++        (minAfps < pIMX662Ctx->CurMode.ae_info.min_fps))
++        return RET_FAILURE;
++    pIMX662Ctx->minAfps = minAfps;
++    pIMX662Ctx->CurMode.ae_info.min_afps = minAfps;
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetSensorIspStatusIss(IsiSensorHandle_t handle,
++                               IsiSensorIspStatus_t *pSensorIspStatus)
++{
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    if (pIMX662Ctx->CurMode.hdr_mode == SENSOR_MODE_HDR_NATIVE) {
++        pSensorIspStatus->useSensorAWB = true;
++        pSensorIspStatus->useSensorBLC = true;
++    } else {
++        pSensorIspStatus->useSensorAWB = false;
++        pSensorIspStatus->useSensorBLC = false;
++    }
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++#ifndef ISI_LITE
++static RESULT IMX662_IsiSensorSetBlcIss(IsiSensorHandle_t handle, IsiSensorBlc_t * pBlc)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pBlc == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_blc_s SensorBlc;
++    SensorBlc.red = pBlc->red;
++    SensorBlc.gb = pBlc->gb;
++    SensorBlc.gr = pBlc->gr;
++    SensorBlc.blue = pBlc->blue;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_BLC, &SensorBlc);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorSetWBIss(IsiSensorHandle_t handle, IsiSensorWB_t *pWb)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pWb == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_white_balance_s SensorWb;
++    SensorWb.r_gain = pWb->r_gain;
++    SensorWb.gr_gain = pWb->gr_gain;
++    SensorWb.gb_gain = pWb->gb_gain;
++    SensorWb.b_gain = pWb->b_gain;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_WB, &SensorWb);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSensorGetExpandCurveIss(IsiSensorHandle_t handle, IsiSensorExpandCurve_t *pExpandCurve)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX662_INFO, "%s: (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    if (pExpandCurve == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_EXPAND_CURVE, pExpandCurve);
++    if (ret != 0) {
++        TRACE(IMX662_ERROR, "%s: get  expand cure error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetTestPatternIss(IsiSensorHandle_t handle,
++                                       IsiSensorTpgMode_e  tpgMode)
++{
++    int32_t ret = 0;
++
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX662Ctx->IsiCtx.HalHandle;
++
++    struct sensor_test_pattern_s TestPattern;
++    if (tpgMode == ISI_TPG_DISABLE) {
++        TestPattern.enable = 0;
++        TestPattern.pattern = 0;
++    } else {
++        TestPattern.enable = 1;
++        TestPattern.pattern = (uint32_t)tpgMode - 1;
++    }
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_TEST_PATTERN, &TestPattern);
++    if (ret != 0)
++    {
++        TRACE(IMX662_ERROR, "%s: set test pattern %d error\n", __func__, tpgMode);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX662_INFO, "%s: test pattern enable[%d] mode[%d]\n", __func__, TestPattern.enable, TestPattern.pattern);
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiFocusSetupIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiFocusReleaseIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiFocusGetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiFocusSetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetFocusCalibrateIss(IsiSensorHandle_t handle, IsiFoucsCalibAttr_t *pFocusCalib)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiGetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t *pExposure)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    if (pIMX662Ctx->AEStartExposure == 0) {
++        pIMX662Ctx->AEStartExposure =
++            (uint64_t)pIMX662Ctx->CurMode.ae_info.start_exposure *
++            pIMX662Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++           
++    }
++    *pExposure =  pIMX662Ctx->AEStartExposure;
++    TRACE(IMX662_INFO, "%s:get start exposure %d\n", __func__, pIMX662Ctx->AEStartExposure);
++
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX662_IsiSetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t exposure)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++    IMX662_Context_t *pIMX662Ctx = (IMX662_Context_t *) handle;
++
++    pIMX662Ctx->AEStartExposure = exposure;
++    TRACE(IMX662_INFO, "set start exposure %d\n", __func__,pIMX662Ctx->AEStartExposure);
++    TRACE(IMX662_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++#endif
++
++RESULT IMX662_IsiGetSensorIss(IsiSensor_t *pIsiSensor)
++{
++    TRACE( IMX662_INFO, "%s (enter)\n", __func__);
++
++    if (pIsiSensor == NULL)
++        return RET_NULL_POINTER;
++     pIsiSensor->pszName                         = SensorName;
++     pIsiSensor->pIsiSensorSetPowerIss           = IMX662_IsiSensorSetPowerIss;
++     pIsiSensor->pIsiCreateSensorIss             = IMX662_IsiCreateSensorIss;
++     pIsiSensor->pIsiReleaseSensorIss            = IMX662_IsiReleaseSensorIss;
++     pIsiSensor->pIsiRegisterReadIss             = IMX662_IsiRegisterReadIss;
++     pIsiSensor->pIsiRegisterWriteIss            = IMX662_IsiRegisterWriteIss;
++     pIsiSensor->pIsiGetSensorModeIss            = IMX662_IsiGetSensorModeIss;
++     pIsiSensor->pIsiSetSensorModeIss            = IMX662_IsiSetSensorModeIss;
++     pIsiSensor->pIsiQuerySensorIss              = IMX662_IsiQuerySensorIss;
++     pIsiSensor->pIsiGetCapsIss                  = IMX662_IsiGetCapsIss;
++     pIsiSensor->pIsiSetupSensorIss              = IMX662_IsiSetupSensorIss;
++     pIsiSensor->pIsiGetSensorRevisionIss        = IMX662_IsiGetSensorRevisionIss;
++     pIsiSensor->pIsiCheckSensorConnectionIss    = IMX662_IsiCheckSensorConnectionIss;
++     pIsiSensor->pIsiSensorSetStreamingIss       = IMX662_IsiSensorSetStreamingIss;
++     pIsiSensor->pIsiGetAeInfoIss                = IMX662_IsiGetAeInfoIss;
++     pIsiSensor->pIsiSetHdrRatioIss              = IMX662_IsiSetHdrRatioIss;
++     pIsiSensor->pIsiGetIntegrationTimeIss       = IMX662_IsiGetIntegrationTimeIss;
++     pIsiSensor->pIsiSetIntegrationTimeIss       = IMX662_IsiSetIntegrationTimeIss;
++     pIsiSensor->pIsiGetGainIss                  = IMX662_IsiGetGainIss;
++     pIsiSensor->pIsiSetGainIss                  = IMX662_IsiSetGainIss;
++     pIsiSensor->pIsiGetSensorFpsIss             = IMX662_IsiGetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorFpsIss             = IMX662_IsiSetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorAfpsLimitsIss      = IMX662_IsiSetSensorAfpsLimitsIss;
++     pIsiSensor->pIsiGetSensorIspStatusIss       = IMX662_IsiGetSensorIspStatusIss;
++#ifndef ISI_LITE
++    pIsiSensor->pIsiSensorSetBlcIss              = IMX662_IsiSensorSetBlcIss;
++    pIsiSensor->pIsiSensorSetWBIss               = IMX662_IsiSensorSetWBIss;
++    pIsiSensor->pIsiSensorGetExpandCurveIss      = IMX662_IsiSensorGetExpandCurveIss;
++    pIsiSensor->pIsiActivateTestPatternIss       = IMX662_IsiSetTestPatternIss;
++    pIsiSensor->pIsiFocusSetupIss                = IMX662_IsiFocusSetupIss;
++    pIsiSensor->pIsiFocusReleaseIss              = IMX662_IsiFocusReleaseIss;
++    pIsiSensor->pIsiFocusSetIss                  = IMX662_IsiFocusSetIss;
++    pIsiSensor->pIsiFocusGetIss                  = IMX662_IsiFocusGetIss;
++    pIsiSensor->pIsiGetFocusCalibrateIss         = IMX662_IsiGetFocusCalibrateIss;
++    pIsiSensor->pIsiSetAeStartExposureIss        = IMX662_IsiSetAeStartExposureIs;
++    pIsiSensor->pIsiGetAeStartExposureIss        = IMX662_IsiGetAeStartExposureIs;
++#endif
++    TRACE( IMX662_INFO, "%s (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++/*****************************************************************************
++* each sensor driver need declare this struct for isi load
++*****************************************************************************/
++IsiCamDrvConfig_t IsiCamDrvConfig = {
++    .CameraDriverID = 0x0662,
++    .pIsiHalQuerySensor = IMX662_IsiHalQuerySensorIss,
++    .pfIsiGetSensorIss = IMX662_IsiGetSensorIss,
++};
+\ No newline at end of file
+diff --git a/units/isi/drv/imx676/CMakeLists.txt b/units/isi/drv/imx676/CMakeLists.txt
+new file mode 100644
+index 0000000..614e337
+--- /dev/null
++++ b/units/isi/drv/imx676/CMakeLists.txt
+@@ -0,0 +1,122 @@
++cmake_minimum_required(VERSION 2.6)
++
++# define module name & interface version
++set (module imx676)
++
++# define interface version
++set (${module}_INTERFACE_CURRENT  1)
++set (${module}_INTERFACE_REVISION 0)
++set (${module}_INTERFACE_AGE      0)
++
++# we want to compile all .c files as default
++file(GLOB libsources source/IMX676.c )
++
++# set public headers, these get installed
++file(GLOB pub_headers include/*.h)
++
++# define include paths
++include_directories(
++    include
++    include_priv
++    ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include
++    )
++
++# module specific defines
++###add_definitions(-Wno-error=unused-function)
++
++# add lib to build env
++#add_library(${module}_static STATIC ${libsources})
++add_library(${module}_shared SHARED ${libsources})
++
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES OUTPUT_NAME     ${module})
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES LINK_FLAGS      -static)
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES OUTPUT_NAME     ${module})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES LINK_FLAGS      -shared)
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES SOVERSION       ${${module}_INTERFACE_CURRENT})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES VERSION         ${${module}_INTERFACE_CURRENT}.${${module}_INTERFACE_REVISION}.${${module}_INTERFACE_AGE})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++# add convenience target: put sensor driver into the 'bin' output dir as well
++if ( NOT ANDROID )
++add_custom_target(${module}.drv
++                  ALL
++                  COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${module}.drv
++                  DEPENDS ${module}_shared
++                  COMMENT "Copying ${module} driver module"
++                  )
++endif()
++
++# define lib dependencies
++#target_link_libraries(${module}_static
++#                      ${platform_libs}
++#                      ${base_libs}
++#                      ${drv_libs}
++#                      isi_shared
++#                      )
++
++# add link libs, or dlopen failed on Android
++if (ANDROID)
++if (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${platform_libs}
++                      ${base_libs}
++                      ${drv_libs}
++                      isi_shared
++                      )
++else (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${android_partial_platform_libs}
++                      ${android_partial_base_libs}
++                      ${android_partial_drv_libs}
++                      isi_shared
++                      )
++add_library(PrebuiltLibs SHARED IMPORTED)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libhal.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libbufferpool.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libcameric_drv.so)
++target_link_libraries(${module}_shared PRIVATE PrebuiltLibs)
++endif (GENERATE_PARTITION_BUILD)
++endif (ANDROID)
++
++# define stuff to install
++#install(TARGETS ${module}_static
++#        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++#        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
++#        )
++
++install(TARGETS ${module}_shared
++        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        LIBRARY         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        )
++
++# install the sensor driver as well, but to 'bin' location!
++install(FILES       ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT}
++        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++        RENAME      ${module}.drv
++        )
++
++if( DEFINED APPSHELL_TOP_COMPILE)
++add_custom_target(copy_shell_libs_${module} ALL
++       COMMENT "##Copy libs to shell libs"
++       COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so ${CMAKE_HOME_DIRECTORY}/shell_libs/ispcore/${PLATFORM}/lib${module}.so
++       #COMMAND ${CMAKE_COMMAND} -E copy_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/${module} ${CMAKE_HOME_DIRECTORY}/shell_libs/include/units_headers/${module}
++)
++add_dependencies(copy_shell_libs_${module} ${module}_shared)
++endif( DEFINED APPSHELL_TOP_COMPILE)
++
++if (NOT GENERATE_PARTITION_BUILD)
++add_custom_target(${module}_create_isi_dir
++                  COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/isi
++                  COMMENT "Create isi dir for ${module}")
++add_dependencies(${module}_create_isi_dir ${module}_shared)
++endif (NOT GENERATE_PARTITION_BUILD)
++
++unset(HEADER_CP_VAR)
++# create common targets for this module
++include(${UNITS_TOP_DIRECTORY}/targets.cmake)
++
++# create calib data targets
++add_subdirectory(calib)
+\ No newline at end of file
+diff --git a/units/isi/drv/imx676/Sensor0_Entry.cfg b/units/isi/drv/imx676/Sensor0_Entry.cfg
+new file mode 100644
+index 0000000..5d305e2
+--- /dev/null
++++ b/units/isi/drv/imx676/Sensor0_Entry.cfg
+@@ -0,0 +1,15 @@
++name = "imx676"
++drv = "imx676.drv"
++mode = 0
++[mode.0]
++xml = "IMX676_Basic_3536x3072.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json"
++[mode.1]
++xml = "IMX676_Basic_3536x2140.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json"
++[mode.2]
++xml = "IMX676_Basic_1776x1778.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_1776x1778.json"
++[mode.3]
++xml = "IMX676_Basic_1760x1070.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json"
+\ No newline at end of file
+diff --git a/units/isi/drv/imx676/Sensor1_Entry.cfg b/units/isi/drv/imx676/Sensor1_Entry.cfg
+new file mode 100644
+index 0000000..4f7b29a
+--- /dev/null
++++ b/units/isi/drv/imx676/Sensor1_Entry.cfg
+@@ -0,0 +1,15 @@
++name = "imx676"
++drv = "imx676.drv"
++mode = 0
++[mode.0]
++xml = "IMX676_Basic_3536x3072.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_3536x3072.json"
++[mode.1]
++xml = "IMX676_Basic_3536x2140.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_3536x2140.json"
++[mode.2]
++xml = "IMX676_Basic_1776x1778.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_1760x1778.json"
++[mode.3]
++xml = "IMX676_Basic_1760x1070.xml"
++dwe = "dewarp_config/sensor_dwe_IMX676_Basic_1760x1070.json"
+diff --git a/units/isi/drv/imx676/calib/CMakeLists.txt b/units/isi/drv/imx676/calib/CMakeLists.txt
+new file mode 100644
+index 0000000..12d0cb6
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/CMakeLists.txt
+@@ -0,0 +1,42 @@
++cmake_minimum_required(VERSION 2.6)
++
++# use upper level module name
++
++# get calib data filenames
++file(GLOB_RECURSE calib_files *.xml)
++list(SORT calib_files)
++
++# a nice helper function
++function(add_calib_target ${calib_file})
++    # get calib data file's base name
++    get_filename_component(base_name ${calib_file} NAME_WE)
++
++    # add target to put sensor driver calibration data file into the 'bin' output and create a similar named symlink to the driver as well
++    add_custom_target(${base_name}_calib
++                      ALL
++                      COMMAND ${CMAKE_COMMAND} -E copy ${calib_file} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.xml
++                      #COMMAND ${CMAKE_COMMAND} -E create_symlink ${module}.drv ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.drv
++                      DEPENDS ${calib_file}
++                      COMMENT "Configuring ${base_name} calibration database"
++                      )
++
++#    add_dependencies(${module}_static
++#                     ${base_name}_calib
++#                     )
++
++    add_dependencies(${module}_shared
++                     ${base_name}_calib
++                     )
++
++    # install the sensor driver config & similar named driver symlink as well, but to 'bin' location!
++    install(FILES       ${calib_file}
++            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++            RENAME      ${base_name}.xml
++            )
++    install(CODE "${CMAKE_COMMAND} -E create_symlink ${module}.drv ${CMAKE_INSTALL_PREFIX}/bin/${base_name}.drv")
++endfunction(add_calib_target)
++
++# loop over all calib data files
++foreach(calib_file ${calib_files})
++    add_calib_target(calib_file)
++endforeach(calib_file)
+\ No newline at end of file
+diff --git a/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1760x1070.xml b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1760x1070.xml
+new file mode 100644
+index 0000000..40fab9d
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1760x1070.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX676
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 47]">
++         Basic_1760x1070
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1760]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 1070]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  1760x1070
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  1760x1070
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.385336 0.429556 0.18511]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.71194 0.0097675 0.702172 0.39976 -0.816438 0.41668]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.820917 -0.571048 -2.554]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.013819 0.00722114 0.0011897 -0.00399385 -0.00833074 -0.011908 -0.0146032 -0.016352 -0.0171647 -0.0169741 -0.0156926 -0.0132803 -0.00972973 -0.00487877 0.00123884 0.010934]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.00381903 0.00277886 0.0088103 0.0139938 0.0183307 0.021908 0.0246032 0.026352 0.0271647 0.0269741 0.0256926 0.0232803 0.0197297 0.0148788 0.00876116 -0.00093391]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.21686 0.194643 0.174241 0.155147 0.138037 0.12253 0.109015 0.0975558 0.0887584 0.0823533 0.0786269 0.0779057 0.0804235 0.0865994 0.0966112 0.11696]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [-0.0168599 0.00535737 0.0257592 0.0448526 0.0619626 0.07747 0.090985 0.102444 0.111242 0.117647 0.121373 0.122094 0.119576 0.113401 0.103389 0.083043]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.3171]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 2.0477]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 2.0877]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.7554]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [8617.92 10262.6 10262.6 16308.0457]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 944.5374]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0244719 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1760x1070
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1760x1070_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.33093 1 1 2.5447]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-89.6314 -107.172 -129.623]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_102
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [579.99 513.212 513.212 3466.5393]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 210.372]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.202144 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1760x1070
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1760x1070_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [2.08721 1 1 1.5219]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-93.2398 -100.957 -102.7025]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [871.154 668.311 668.311 2999.7143]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 234.2648]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0753561 -0.054763]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1760x1070
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1760x1070_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.5192 1 1 2.2116]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-91.4644 -105.469 -92.3084]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1760x1070_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [90 104 109 113 115 116 118 119]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [62 65 68 68 70 68 70 69]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1760x1070_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [90 104 109 113 115 116 118 119]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [62 65 68 68 70 68 70 69]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1760x1070_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [90 104 109 113 115 116 118 119]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [62 65 68 68 70 68 70 69]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1760x1070_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [90 104 109 113 115 116 118 119]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [62 65 68 68 70 68 70 69]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_102
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 102]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-89.6314 -107.172 -129.623]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.33093 1 1 2.5447]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-93.2398 -100.957 -102.7025]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [2.08721 1 1 1.5219]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-91.4644 -105.469 -92.3084]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.5192 1 1 2.2116]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.48653 -1.45883 0.0142414 -0.744926 2.08514 -0.294523 -0.0837757 -1.02133 2.1284]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-85.2607 -107.939 -95.5088]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.70434 1 1 2.2565]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1760x1070_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1760x1070_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1760x1070_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1760x1070
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1760x1070
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1776x1778.xml b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1776x1778.xml
+new file mode 100644
+index 0000000..b85e4dd
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_1776x1778.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX676
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 47]">
++         Basic_1776x1778
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1776]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 1778]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  1776x1778
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  1776x1778
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.385336 0.429556 0.18511]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.71194 0.0097675 0.702172 0.39976 -0.816438 0.41668]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.820917 -0.571048 -2.554]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.013819 0.00722114 0.0011897 -0.00399385 -0.00833074 -0.011908 -0.0146032 -0.016352 -0.0171647 -0.0169741 -0.0156926 -0.0132803 -0.00972973 -0.00487877 0.00123884 0.010934]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.00381903 0.00277886 0.0088103 0.0139938 0.0183307 0.021908 0.0246032 0.026352 0.0271647 0.0269741 0.0256926 0.0232803 0.0197297 0.0148788 0.00876116 -0.00093391]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.21686 0.194643 0.174241 0.155147 0.138037 0.12253 0.109015 0.0975558 0.0887584 0.0823533 0.0786269 0.0779057 0.0804235 0.0865994 0.0966112 0.11696]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [-0.0168599 0.00535737 0.0257592 0.0448526 0.0619626 0.07747 0.090985 0.102444 0.111242 0.117647 0.121373 0.122094 0.119576 0.113401 0.103389 0.083043]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.3171]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 2.0477]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 2.0877]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.7554]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [8617.92 10262.6 10262.6 16308.0457]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 944.5374]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0244719 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1776x1778
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1776x1778_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.33093 1 1 2.5447]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-89.6314 -107.172 -129.623]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_102
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [579.99 513.212 513.212 3466.5393]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 210.372]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.202144 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1776x1778
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1776x1778_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [2.08721 1 1 1.5219]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-93.2398 -100.957 -102.7025]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [871.154 668.311 668.311 2999.7143]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 234.2648]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0753561 -0.054763]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1776x1778
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1776x1778_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.5192 1 1 2.2116]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-91.4644 -105.469 -92.3084]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1776x1778_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [82 100 107 114 118 122 123 122]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [82 98 108 115 120 121 122 123]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1776x1778_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [82 100 107 114 118 122 123 122]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [82 98 108 115 120 121 122 123]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1776x1778_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [82 100 107 114 118 122 123 122]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [82 98 108 115 120 121 122 123]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1776x1778_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [82 100 107 114 118 122 123 122]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [82 98 108 115 120 121 122 123]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_102
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 102]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-89.6314 -107.172 -129.623]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.33093 1 1 2.5447]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-93.2398 -100.957 -102.7025]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [2.08721 1 1 1.5219]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-91.4644 -105.469 -92.3084]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.5192 1 1 2.2116]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.48653 -1.45883 0.0142414 -0.744926 2.08514 -0.294523 -0.0837757 -1.02133 2.1284]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-85.2607 -107.939 -95.5088]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.70434 1 1 2.2565]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1776x1778_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1776x1778_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1776x1778_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1776x1778
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1776x1778
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x2140.xml b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x2140.xml
+new file mode 100644
+index 0000000..cbd2531
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x2140.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX676
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 47]">
++         Basic_3536x2140
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 3536]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 2140]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  3536x2140
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  3536x2140
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.385336 0.429556 0.18511]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.71194 0.0097675 0.702172 0.39976 -0.816438 0.41668]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.820917 -0.571048 -2.554]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.013819 0.00722114 0.0011897 -0.00399385 -0.00833074 -0.011908 -0.0146032 -0.016352 -0.0171647 -0.0169741 -0.0156926 -0.0132803 -0.00972973 -0.00487877 0.00123884 0.010934]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.00381903 0.00277886 0.0088103 0.0139938 0.0183307 0.021908 0.0246032 0.026352 0.0271647 0.0269741 0.0256926 0.0232803 0.0197297 0.0148788 0.00876116 -0.00093391]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.21686 0.194643 0.174241 0.155147 0.138037 0.12253 0.109015 0.0975558 0.0887584 0.0823533 0.0786269 0.0779057 0.0804235 0.0865994 0.0966112 0.11696]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [-0.0168599 0.00535737 0.0257592 0.0448526 0.0619626 0.07747 0.090985 0.102444 0.111242 0.117647 0.121373 0.122094 0.119576 0.113401 0.103389 0.083043]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.3171]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 2.0477]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 2.0877]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.7554]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [8617.92 10262.6 10262.6 16308.0457]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 944.5374]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0244719 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x2140
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        3536x2140_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.33093 1 1 2.5447]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-89.6314 -107.172 -129.623]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_102
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [579.99 513.212 513.212 3466.5393]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 210.372]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.202144 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x2140
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3536x2140_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [2.08721 1 1 1.5219]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-93.2398 -100.957 -102.7025]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [871.154 668.311 668.311 2999.7143]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 234.2648]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0753561 -0.054763]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x2140
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3536x2140_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.5192 1 1 2.2116]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-91.4644 -105.469 -92.3084]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3536x2140_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [198 210 216 223 227 230 236 236]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [129 132 133 136 135 138 138 139]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3536x2140_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [198 210 216 223 227 230 236 236]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [129 132 133 136 135 138 138 139]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3536x2140_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [198 210 216 223 227 230 236 236]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [129 132 133 136 135 138 138 139]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3536x2140_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [198 210 216 223 227 230 236 236]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [129 132 133 136 135 138 138 139]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_102
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 102]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-89.6314 -107.172 -129.623]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.33093 1 1 2.5447]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-93.2398 -100.957 -102.7025]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [2.08721 1 1 1.5219]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-91.4644 -105.469 -92.3084]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.5192 1 1 2.2116]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.48653 -1.45883 0.0142414 -0.744926 2.08514 -0.294523 -0.0837757 -1.02133 2.1284]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-85.2607 -107.939 -95.5088]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.70434 1 1 2.2565]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x2140_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x2140_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x2140_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [50 50 50 50]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x2140
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x2140
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x3072.xml b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x3072.xml
+new file mode 100644
+index 0000000..89988c5
+--- /dev/null
++++ b/units/isi/drv/imx676/calib/IMX676/IMX676_Basic_3536x3072.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX676
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 47]">
++         Basic_3536x3072
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 3536]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 3072]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  3536x3072
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  3536x3072
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.385336 0.429556 0.18511]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.71194 0.0097675 0.702172 0.39976 -0.816438 0.41668]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.820917 -0.571048 -2.554]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.013819 0.00722114 0.0011897 -0.00399385 -0.00833074 -0.011908 -0.0146032 -0.016352 -0.0171647 -0.0169741 -0.0156926 -0.0132803 -0.00972973 -0.00487877 0.00123884 0.010934]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.31707 1.36578 1.41448 1.46319 1.51189 1.5606 1.6093 1.65801 1.70671 1.75542 1.80412 1.85283 1.90153 1.95024 1.99895 2.0477]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.00381903 0.00277886 0.0088103 0.0139938 0.0183307 0.021908 0.0246032 0.026352 0.0271647 0.0269741 0.0256926 0.0232803 0.0197297 0.0148788 0.00876116 -0.00093391]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.21686 0.194643 0.174241 0.155147 0.138037 0.12253 0.109015 0.0975558 0.0887584 0.0823533 0.0786269 0.0779057 0.0804235 0.0865994 0.0966112 0.11696]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.885843 0.971687 1.05753 1.14337 1.22922 1.31506 1.4009 1.48675 1.57259 1.65843 1.74428 1.83012 1.91596 2.00181 2.0877]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [-0.0168599 0.00535737 0.0257592 0.0448526 0.0619626 0.07747 0.090985 0.102444 0.111242 0.117647 0.121373 0.122094 0.119576 0.113401 0.103389 0.083043]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.3171]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 2.0477]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 2.0877]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.7554]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [8617.92 10262.6 10262.6 16308.0457]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 944.5374]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.7 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0244719 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x3072
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        3536x3072_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.33093 1 1 2.5447]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-89.6314 -107.172 -129.623]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_102
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [579.99 513.212 513.212 3466.5393]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 210.372]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.202144 -0.045335]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x3072
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3536x3072_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [2.08721 1 1 1.5219]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-93.2398 -100.957 -102.7025]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [871.154 668.311 668.311 2999.7143]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 234.2648]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0753561 -0.054763]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3536x3072
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3536x3072_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.5192 1 1 2.2116]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-91.4644 -105.469 -92.3084]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_103
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3536x3072_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [192 206 215 224 229 233 238 239]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [172 182 190 194 198 200 205 205]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3536x3072_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [192 206 215 224 229 233 238 239]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [172 182 190 194 198 200 205 205]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3536x3072_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [192 206 215 224 229 233 238 239]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [172 182 190 194 198 200 205 205]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3536x3072_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [192 206 215 224 229 233 238 239]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [172 182 190 194 198 200 205 205]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_102
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 102]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.86273 -0.341039 -0.499804 -0.864344 2.29638 -0.398967 -0.0342477 -1.78307 2.8508]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-89.6314 -107.172 -129.623]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.33093 1 1 2.5447]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.09003 -0.925784 -0.125778 -0.544328 2.17467 -0.579717 -0.0888339 -0.628361 1.7423]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-93.2398 -100.957 -102.7025]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [2.08721 1 1 1.5219]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.00153 -0.707809 -0.223527 -0.811689 2.29141 -0.367318 -0.0677193 -1.08569 2.176]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-91.4644 -105.469 -92.3084]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.5192 1 1 2.2116]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_103
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 103]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.48653 -1.45883 0.0142414 -0.744926 2.08514 -0.294523 -0.0837757 -1.02133 2.1284]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-85.2607 -107.939 -95.5088]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.70434 1 1 2.2565]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x3072_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x3072_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3536x3072_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [50 50 50 50]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3536x3072
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3536x3072
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx676/source/IMX676.c b/units/isi/drv/imx676/source/IMX676.c
+new file mode 100644
+index 0000000..9387b27
+--- /dev/null
++++ b/units/isi/drv/imx676/source/IMX676.c
+@@ -0,0 +1,1268 @@
++/******************************************************************************\
++|* Copyright (c) 2020 by VeriSilicon Holdings Co., Ltd. ("VeriSilicon")       *|
++|* All Rights Reserved.                                                       *|
++|*                                                                            *|
++|* The material in this file is confidential and contains trade secrets of    *|
++|* of VeriSilicon.  This is proprietary information owned or licensed by      *|
++|* VeriSilicon.  No part of this work may be disclosed, reproduced, copied,   *|
++|* transmitted, or used in any way for any purpose, without the express       *|
++|* written permission of VeriSilicon.                                         *|
++|*                                                                            *|
++\******************************************************************************/
++
++#include <ebase/types.h>
++#include <ebase/trace.h>
++#include <ebase/builtins.h>
++#include <common/return_codes.h>
++#include <common/misc.h>
++#include <sys/ioctl.h>
++#include <fcntl.h>
++#include "isi.h"
++#include "isi_iss.h"
++#include "isi_priv.h"
++#include "vvsensor.h"
++
++CREATE_TRACER( IMX676_INFO , "IMX676: ", INFO,    1);
++CREATE_TRACER( IMX676_WARN , "IMX676: ", WARNING, 1);
++CREATE_TRACER( IMX676_ERROR, "IMX676: ", ERROR,   1);
++
++#ifdef SUBDEV_V4L2
++#include <sys/ioctl.h>
++#include <sys/mman.h>
++#include <fcntl.h>
++#include <linux/videodev2.h>
++#include <linux/v4l2-subdev.h>
++//#undef TRACE
++//#define TRACE(x, ...)
++#endif
++
++static const char SensorName[16] = "imx676";
++
++typedef struct IMX676_Context_s
++{
++    IsiSensorContext_t  IsiCtx;
++    struct vvcam_mode_info_s CurMode;
++    IsiSensorAeInfo_t AeInfo;
++    IsiSensorIntTime_t IntTime;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    IsiSensorGain_t SensorGain;
++    uint32_t minAfps;
++    uint64_t AEStartExposure;
++} IMX676_Context_t;
++
++static RESULT IMX676_IsiSensorSetPowerIss(IsiSensorHandle_t handle, bool_t on)
++{
++    int ret = 0;
++
++    TRACE( IMX676_INFO, "%s: (enter)\n", __func__);
++    TRACE( IMX676_INFO, "%s: set power %d\n", __func__,on);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    int32_t power = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_POWER, &power);
++    if (ret != 0){
++        TRACE(IMX676_ERROR, "%s set power %d error\n", __func__,power);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorGetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (!pclk)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CLK, pclk);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s get clock error\n", __func__);
++        return RET_FAILURE;
++    } 
++    
++    TRACE( IMX676_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++    TRACE( IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorSetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pclk == NULL)
++        return RET_NULL_POINTER;
++    
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_CLK, &pclk);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX676_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++
++    TRACE( IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiResetSensorIss(IsiSensorHandle_t handle)
++{
++    int ret = 0;
++
++    TRACE( IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_RESET, NULL);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s set reset error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiRegisterReadIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        uint32_t * pValue)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_READ_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: read sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    *pValue = sccb_data.data;
++
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiRegisterWriteIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        const uint32_t value)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = value;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_WRITE_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: write sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_UpdateIsiAEInfo(IsiSensorHandle_t handle)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    IsiSensorAeInfo_t *pAeInfo = &pIMX676Ctx->AeInfo;
++    pAeInfo->oneLineExpTime = pIMX676Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++
++    if (pIMX676Ctx->CurMode.hdr_mode == SENSOR_MODE_LINEAR) {
++        pAeInfo->maxIntTime.linearInt =
++            pIMX676Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->minIntTime.linearInt =
++            pIMX676Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->maxAGain.linearGainParas = pIMX676Ctx->CurMode.ae_info.max_again;
++        pAeInfo->minAGain.linearGainParas = pIMX676Ctx->CurMode.ae_info.min_again;
++        pAeInfo->maxDGain.linearGainParas = pIMX676Ctx->CurMode.ae_info.max_dgain;
++        pAeInfo->minDGain.linearGainParas = pIMX676Ctx->CurMode.ae_info.min_dgain;
++    } else {
++        switch (pIMX676Ctx->CurMode.stitching_mode) {
++            case SENSOR_STITCHING_DUAL_DCG:
++            case SENSOR_STITCHING_3DOL:
++            case SENSOR_STITCHING_LINEBYLINE:
++                pAeInfo->maxIntTime.triInt.triSIntTime =
++                    pIMX676Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triSIntTime =
++                    pIMX676Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                
++                pAeInfo->maxIntTime.triInt.triIntTime =
++                    pIMX676Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triIntTime =
++                    pIMX676Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX676Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG) {
++                    pAeInfo->maxIntTime.triInt.triLIntTime = pAeInfo->maxIntTime.triInt.triIntTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime = pAeInfo->minIntTime.triInt.triIntTime;
++                } else {
++                    pAeInfo->maxIntTime.triInt.triLIntTime =
++                        pIMX676Ctx->CurMode.ae_info.max_longintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime =
++                        pIMX676Ctx->CurMode.ae_info.min_longintegration_line * pAeInfo->oneLineExpTime;
++                }
++
++                pAeInfo->maxAGain.triGainParas.triSGain = pIMX676Ctx->CurMode.ae_info.max_short_again;
++                pAeInfo->minAGain.triGainParas.triSGain = pIMX676Ctx->CurMode.ae_info.min_short_again;
++                pAeInfo->maxDGain.triGainParas.triSGain = pIMX676Ctx->CurMode.ae_info.max_short_dgain;
++                pAeInfo->minDGain.triGainParas.triSGain = pIMX676Ctx->CurMode.ae_info.min_short_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triGain = pIMX676Ctx->CurMode.ae_info.max_again;
++                pAeInfo->minAGain.triGainParas.triGain = pIMX676Ctx->CurMode.ae_info.min_again;
++                pAeInfo->maxDGain.triGainParas.triGain = pIMX676Ctx->CurMode.ae_info.max_dgain;
++                pAeInfo->minDGain.triGainParas.triGain = pIMX676Ctx->CurMode.ae_info.min_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triLGain = pIMX676Ctx->CurMode.ae_info.max_long_again;
++                pAeInfo->minAGain.triGainParas.triLGain = pIMX676Ctx->CurMode.ae_info.min_long_again;
++                pAeInfo->maxDGain.triGainParas.triLGain = pIMX676Ctx->CurMode.ae_info.max_long_dgain;
++                pAeInfo->minDGain.triGainParas.triLGain = pIMX676Ctx->CurMode.ae_info.min_long_dgain;
++                break;
++            case SENSOR_STITCHING_DUAL_DCG_NOWAIT:
++            case SENSOR_STITCHING_16BIT_COMPRESS:
++            case SENSOR_STITCHING_L_AND_S:
++            case SENSOR_STITCHING_2DOL:
++                pAeInfo->maxIntTime.dualInt.dualIntTime =
++                    pIMX676Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.dualInt.dualIntTime =
++                    pIMX676Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX676Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime = pAeInfo->maxIntTime.dualInt.dualIntTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime = pAeInfo->minIntTime.dualInt.dualIntTime;
++                } else {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime =
++                        pIMX676Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime =
++                        pIMX676Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                }
++                
++                if (pIMX676Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.min_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.max_long_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.min_long_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.max_long_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.min_long_dgain;
++                } else {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.max_short_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.min_short_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.max_short_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX676Ctx->CurMode.ae_info.min_short_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX676Ctx->CurMode.ae_info.min_dgain;
++                }
++                
++                break;
++            default:
++                break;
++        }
++    }
++    pAeInfo->gainStep = pIMX676Ctx->CurMode.ae_info.gain_step;
++    pAeInfo->currFps  = pIMX676Ctx->CurMode.ae_info.cur_fps;
++    pAeInfo->maxFps   = pIMX676Ctx->CurMode.ae_info.max_fps;
++    pAeInfo->minFps   = pIMX676Ctx->CurMode.ae_info.min_fps;
++    pAeInfo->minAfps  = pIMX676Ctx->CurMode.ae_info.min_afps;
++    pAeInfo->hdrRatio[0] = pIMX676Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s;
++    pAeInfo->hdrRatio[1] = pIMX676Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs;
++
++    pAeInfo->intUpdateDlyFrm = pIMX676Ctx->CurMode.ae_info.int_update_delay_frm;
++    pAeInfo->gainUpdateDlyFrm = pIMX676Ctx->CurMode.ae_info.gain_update_delay_frm;
++
++    if (pIMX676Ctx->minAfps != 0) {
++        pAeInfo->minAfps = pIMX676Ctx->minAfps;
++    } 
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    memcpy(pMode, &pIMX676Ctx->CurMode, sizeof(IsiSensorMode_t));
++
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    struct vvcam_mode_info_s sensor_mode;
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    sensor_mode.index = pMode->index;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s set sensor mode failed", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX676Ctx->CurMode, &sensor_mode, sizeof(struct vvcam_mode_info_s));
++    IMX676_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorSetStreamingIss(IsiSensorHandle_t handle,
++                                              bool_t on)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    uint32_t status = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_STREAM, &status);
++    if (ret != 0){
++        TRACE(IMX676_ERROR, "%s set sensor stream %d error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: set streaming %d\n", __func__, on);
++    TRACE(IMX676_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiCreateSensorIss(IsiSensorInstanceConfig_t * pConfig)
++{
++    RESULT result = RET_SUCCESS;
++    IMX676_Context_t *pIMX676Ctx;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    if (!pConfig || !pConfig->pSensor || !pConfig->HalHandle)
++        return RET_NULL_POINTER;
++
++    pIMX676Ctx = (IMX676_Context_t *) malloc(sizeof(IMX676_Context_t));
++    if (!pIMX676Ctx)
++        return RET_OUTOFMEM;
++
++    memset(pIMX676Ctx, 0, sizeof(IMX676_Context_t));
++    pIMX676Ctx->IsiCtx.HalHandle = pConfig->HalHandle;
++    pIMX676Ctx->IsiCtx.pSensor   = pConfig->pSensor;
++    pConfig->hSensor = (IsiSensorHandle_t) pIMX676Ctx;
++
++    result = IMX676_IsiSensorSetPowerIss(pIMX676Ctx, BOOL_TRUE);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s set power error\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    result = IMX676_IsiSensorGetClkIss(pIMX676Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s get clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    clk.status = 1;
++    result = IMX676_IsiSensorSetClkIss(pIMX676Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    result = IMX676_IsiResetSensorIss(pIMX676Ctx);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s retset sensor error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    IsiSensorMode_t SensorMode;
++    SensorMode.index = pConfig->SensorModeIndex;
++    result = IMX676_IsiSetSensorModeIss(pIMX676Ctx, &SensorMode);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX676_IsiReleaseSensorIss(IsiSensorHandle_t handle)
++{
++    TRACE(IMX676_INFO, "%s (enter) \n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    if (pIMX676Ctx == NULL)
++        return (RET_WRONG_HANDLE);
++
++    IMX676_IsiSensorSetStreamingIss(pIMX676Ctx, BOOL_FALSE);
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    IMX676_IsiSensorGetClkIss(pIMX676Ctx, &clk);
++    clk.status = 0;
++    IMX676_IsiSensorSetClkIss(pIMX676Ctx, &clk);
++    IMX676_IsiSensorSetPowerIss(pIMX676Ctx, BOOL_FALSE);
++    free(pIMX676Ctx);
++    pIMX676Ctx = NULL;
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiHalQuerySensorIss(HalHandle_t HalHandle,
++                                          IsiSensorModeInfoArray_t *pSensorMode)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter) \n", __func__);
++
++    if (HalHandle == NULL || pSensorMode == NULL)
++        return RET_NULL_POINTER;
++
++    HalContext_t *pHalCtx = (HalContext_t *)HalHandle;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_QUERY, pSensorMode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiQuerySensorIss(IsiSensorHandle_t handle,
++                                       IsiSensorModeInfoArray_t *pSensorMode)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX676_INFO, "%s (enter) \n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    result = IMX676_IsiHalQuerySensorIss(pIMX676Ctx->IsiCtx.HalHandle,
++                                         pSensorMode);
++    if (result != RET_SUCCESS)
++        TRACE(IMX676_ERROR, "%s: query sensor mode info error!\n", __func__);
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX676_IsiGetCapsIss(IsiSensorHandle_t handle,
++                                   IsiSensorCaps_t * pIsiSensorCaps)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX676_INFO, "%s (enter) \n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    IsiSensorModeInfoArray_t SensorModeInfo;
++    memset(&SensorModeInfo, 0, sizeof(IsiSensorModeInfoArray_t));
++    result = IMX676_IsiQuerySensorIss(handle, &SensorModeInfo);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    pIsiSensorCaps->FieldSelection    = ISI_FIELDSEL_BOTH;
++    pIsiSensorCaps->YCSequence        = ISI_YCSEQ_YCBYCR;
++    pIsiSensorCaps->Conv422           = ISI_CONV422_NOCOSITED;
++    pIsiSensorCaps->HPol              = ISI_HPOL_REFPOS;
++    pIsiSensorCaps->VPol              = ISI_VPOL_NEG;
++    pIsiSensorCaps->Edge              = ISI_EDGE_RISING;
++    pIsiSensorCaps->supportModeNum    = SensorModeInfo.count;
++    pIsiSensorCaps->currentMode       = pIMX676Ctx->CurMode.index;
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX676_IsiSetupSensorIss(IsiSensorHandle_t handle,
++                                       const IsiSensorCaps_t *pIsiSensorCaps )
++{
++    int ret = 0;
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    if (pIsiSensorCaps->currentMode != pIMX676Ctx->CurMode.index) {
++        IsiSensorMode_t SensorMode;
++        memset(&SensorMode, 0, sizeof(IsiSensorMode_t));
++        SensorMode.index = pIsiSensorCaps->currentMode;
++        result = IMX676_IsiSetSensorModeIss(handle, &SensorMode);
++        if (result != RET_SUCCESS) {
++            TRACE(IMX676_ERROR, "%s:set sensor mode %d failed!\n",
++                  __func__, SensorMode.index);
++            return result;
++        }
++    }
++
++#ifdef SUBDEV_V4L2
++    struct v4l2_subdev_format format;
++    memset(&format, 0, sizeof(struct v4l2_subdev_format));
++    format.format.width  = pIMX676Ctx->CurMode.size.bounds_width;
++    format.format.height = pIMX676Ctx->CurMode.size.bounds_height;
++    format.which = V4L2_SUBDEV_FORMAT_ACTIVE;
++    format.pad = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VIDIOC_SUBDEV_S_FMT, &format);
++    if (ret != 0){
++        TRACE(IMX676_ERROR, "%s: sensor set format error!\n", __func__);
++        return RET_FAILURE;
++    }
++#else
++    ret = ioctrl(pHalCtx->sensor_fd, VVSENSORIOC_S_INIT, NULL);
++    if (ret != 0){
++        TRACE(IMX676_ERROR, "%s: sensor init error!\n", __func__);
++        return RET_FAILURE;
++    }
++#endif
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetSensorRevisionIss(IsiSensorHandle_t handle, uint32_t *pValue)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pValue == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CHIP_ID, pValue);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: get chip id error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiCheckSensorConnectionIss(IsiSensorHandle_t handle)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    uint32_t ChipId = 0;
++    result = IMX676_IsiGetSensorRevisionIss(handle, &ChipId);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX676_ERROR, "%s:get sensor chip id error!\n",__func__);
++        return RET_FAILURE;
++    }
++
++    if (ChipId != 676) {
++        TRACE(IMX676_ERROR,
++            "%s:ChipID=676,while read sensor Id=0x%x error!\n",
++             __func__, ChipId);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetAeInfoIss(IsiSensorHandle_t handle,
++                                     IsiSensorAeInfo_t *pAeInfo)
++{
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    if (pAeInfo == NULL)
++        return RET_NULL_POINTER;
++
++    memcpy(pAeInfo, &pIMX676Ctx->AeInfo, sizeof(IsiSensorAeInfo_t));
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetHdrRatioIss(IsiSensorHandle_t handle,
++                                       uint8_t hdrRatioNum,
++                                       uint32_t HdrRatio[])
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    struct sensor_hdr_artio_s hdr_ratio;
++    if (hdrRatioNum == 2) {
++        hdr_ratio.ratio_s_vs = HdrRatio[1];
++        hdr_ratio.ratio_l_s = HdrRatio[0];
++    }else {
++        hdr_ratio.ratio_s_vs = HdrRatio[0];
++        hdr_ratio.ratio_l_s = 0;
++    }
++
++    if (hdr_ratio.ratio_s_vs == pIMX676Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs &&
++        hdr_ratio.ratio_l_s == pIMX676Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s)
++        return RET_SUCCESS;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_HDR_RADIO, &hdr_ratio);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR,"%s: set hdr ratio error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s sensor_mode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR,"%s: get mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memcpy(&pIMX676Ctx->CurMode, &sensor_mode, sizeof (struct vvcam_mode_info_s));
++    IMX676_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    memcpy(pIntegrationTime, &pIMX676Ctx->IntTime, sizeof(IsiSensorIntTime_t));
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++
++}
++
++static RESULT IMX676_IsiSetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    int ret = 0;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    uint32_t oneLineTime;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++    printf("\n\nAAAAAAAAAAAAAAA %u\n\n", pIntegrationTime->IntegrationTime.linearInt);
++    if (pIntegrationTime == NULL)
++        return RET_NULL_POINTER;
++
++    oneLineTime =  pIMX676Ctx->AeInfo.oneLineExpTime;
++    pIMX676Ctx->IntTime.expoFrmType = pIntegrationTime->expoFrmType;
++
++    switch (pIntegrationTime->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            IntLine = pIntegrationTime->IntegrationTime.linearInt;
++            if (IntLine != pIMX676Ctx->IntLine) {
++                printf("\n\ngoing into S_EXP ioctl %u\n\n", IntLine);
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor linear exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++               pIMX676Ctx->IntLine = IntLine;
++            }
++            TRACE(IMX676_INFO, "%s set linear exp %d \n", __func__,IntLine);
++            pIMX676Ctx->IntTime.IntegrationTime.linearInt =  IntLine * oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            IntLine = pIntegrationTime->IntegrationTime.dualInt.dualIntTime;
++            if (IntLine != pIMX676Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor dual exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX676Ctx->IntLine = IntLine;
++            }
++
++            if (pIMX676Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                ShortIntLine = pIntegrationTime->IntegrationTime.dualInt.dualSIntTime;
++                if (ShortIntLine != pIMX676Ctx->ShortIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX676_ERROR,"%s:set sensor dual vsexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX676Ctx->ShortIntLine = ShortIntLine;
++                }
++            } else {
++                ShortIntLine = IntLine;
++                pIMX676Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX676_INFO, "%s set dual exp %d short_exp %d\n", __func__, IntLine, ShortIntLine);
++            pIMX676Ctx->IntTime.IntegrationTime.dualInt.dualIntTime  = IntLine + oneLineTime;
++            pIMX676Ctx->IntTime.IntegrationTime.dualInt.dualSIntTime = ShortIntLine + oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            if (pIMX676Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triLIntTime;
++                if (LongIntLine != pIMX676Ctx->LongIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_EXP, &LongIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX676_ERROR,"%s:set sensor tri lexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX676Ctx->LongIntLine = LongIntLine;
++                }
++            } else {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++                pIMX676Ctx->LongIntLine = LongIntLine;
++            }
++
++            IntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++            if (IntLine != pIMX676Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX676Ctx->IntLine = IntLine;
++            }
++            
++            ShortIntLine = pIntegrationTime->IntegrationTime.triInt.triSIntTime;
++            if (ShortIntLine != pIMX676Ctx->ShortIntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri vsexp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX676Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX676_INFO, "%s set tri long exp %d exp %d short_exp %d\n", __func__, LongIntLine, IntLine, ShortIntLine);
++            pIMX676Ctx->IntTime.IntegrationTime.triInt.triLIntTime = LongIntLine + oneLineTime;
++            pIMX676Ctx->IntTime.IntegrationTime.triInt.triIntTime = IntLine + oneLineTime;
++            pIMX676Ctx->IntTime.IntegrationTime.triInt.triSIntTime = ShortIntLine + oneLineTime;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++    
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++    memcpy(pGain, &pIMX676Ctx->SensorGain, sizeof(IsiSensorGain_t));
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    int ret = 0;
++    uint32_t LongGain;
++    uint32_t Gain;
++    uint32_t ShortGain;
++
++    TRACE(IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++
++    pIMX676Ctx->SensorGain.expoFrmType = pGain->expoFrmType;
++    switch (pGain->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            Gain = pGain->gain.linearGainParas;
++            if (pIMX676Ctx->SensorGain.gain.linearGainParas != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor linear gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            pIMX676Ctx->SensorGain.gain.linearGainParas = pGain->gain.linearGainParas;
++            TRACE(IMX676_INFO, "%s set linear gain %d\n", __func__,pGain->gain.linearGainParas);
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            Gain = pGain->gain.dualGainParas.dualGain;
++            if (pIMX676Ctx->SensorGain.gain.dualGainParas.dualGain != Gain) {
++                if (pIMX676Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &Gain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor dual gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.dualGainParas.dualSGain;
++            if (pIMX676Ctx->SensorGain.gain.dualGainParas.dualSGain != ShortGain) {
++                if (pIMX676Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &ShortGain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor dual vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX676_INFO,"%s:set gain%d short gain %d!\n", __func__,Gain,ShortGain);
++            pIMX676Ctx->SensorGain.gain.dualGainParas.dualGain = Gain;
++            pIMX676Ctx->SensorGain.gain.dualGainParas.dualSGain = ShortGain;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            LongGain = pGain->gain.triGainParas.triLGain;
++            if (pIMX676Ctx->SensorGain.gain.triGainParas.triLGain != LongGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &LongGain);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            Gain = pGain->gain.triGainParas.triGain;
++            if (pIMX676Ctx->SensorGain.gain.triGainParas.triGain != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.triGainParas.triSGain;
++            if (pIMX676Ctx->SensorGain.gain.triGainParas.triSGain != ShortGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                if (ret != 0) {
++                    TRACE(IMX676_ERROR,"%s:set sensor tri vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX676_INFO,"%s:set long gain %d gain%d short gain %d!\n", __func__, LongGain, Gain, ShortGain);
++            pIMX676Ctx->SensorGain.gain.triGainParas.triLGain = LongGain;
++            pIMX676Ctx->SensorGain.gain.triGainParas.triGain = Gain;
++            pIMX676Ctx->SensorGain.gain.triGainParas.triSGain = ShortGain;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++
++    TRACE(IMX676_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++
++static RESULT IMX676_IsiGetSensorFpsIss(IsiSensorHandle_t handle, uint32_t * pfps)
++{
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    if (pfps == NULL)
++        return RET_NULL_POINTER;
++
++    *pfps = pIMX676Ctx->CurMode.ae_info.cur_fps;
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetSensorFpsIss(IsiSensorHandle_t handle, uint32_t fps)
++{
++    int ret = 0;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_FPS, &fps);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR,"%s:set sensor fps error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s SensorMode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &SensorMode);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR,"%s:get sensor mode error!\n", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX676Ctx->CurMode, &SensorMode, sizeof(struct vvcam_mode_info_s));
++    IMX676_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++static RESULT IMX676_IsiSetSensorAfpsLimitsIss(IsiSensorHandle_t handle, uint32_t minAfps)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    if ((minAfps > pIMX676Ctx->CurMode.ae_info.max_fps) ||
++        (minAfps < pIMX676Ctx->CurMode.ae_info.min_fps))
++        return RET_FAILURE;
++    pIMX676Ctx->minAfps = minAfps;
++    pIMX676Ctx->CurMode.ae_info.min_afps = minAfps;
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetSensorIspStatusIss(IsiSensorHandle_t handle,
++                               IsiSensorIspStatus_t *pSensorIspStatus)
++{
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    if (pIMX676Ctx->CurMode.hdr_mode == SENSOR_MODE_HDR_NATIVE) {
++        pSensorIspStatus->useSensorAWB = true;
++        pSensorIspStatus->useSensorBLC = true;
++    } else {
++        pSensorIspStatus->useSensorAWB = false;
++        pSensorIspStatus->useSensorBLC = false;
++    }
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++#ifndef ISI_LITE
++static RESULT IMX676_IsiSensorSetBlcIss(IsiSensorHandle_t handle, IsiSensorBlc_t * pBlc)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pBlc == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_blc_s SensorBlc;
++    SensorBlc.red = pBlc->red;
++    SensorBlc.gb = pBlc->gb;
++    SensorBlc.gr = pBlc->gr;
++    SensorBlc.blue = pBlc->blue;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_BLC, &SensorBlc);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorSetWBIss(IsiSensorHandle_t handle, IsiSensorWB_t *pWb)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pWb == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_white_balance_s SensorWb;
++    SensorWb.r_gain = pWb->r_gain;
++    SensorWb.gr_gain = pWb->gr_gain;
++    SensorWb.gb_gain = pWb->gb_gain;
++    SensorWb.b_gain = pWb->b_gain;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_WB, &SensorWb);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSensorGetExpandCurveIss(IsiSensorHandle_t handle, IsiSensorExpandCurve_t *pExpandCurve)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX676_INFO, "%s: (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    if (pExpandCurve == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_EXPAND_CURVE, pExpandCurve);
++    if (ret != 0) {
++        TRACE(IMX676_ERROR, "%s: get  expand cure error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetTestPatternIss(IsiSensorHandle_t handle,
++                                       IsiSensorTpgMode_e  tpgMode)
++{
++    int32_t ret = 0;
++
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX676Ctx->IsiCtx.HalHandle;
++
++    struct sensor_test_pattern_s TestPattern;
++    if (tpgMode == ISI_TPG_DISABLE) {
++        TestPattern.enable = 0;
++        TestPattern.pattern = 0;
++    } else {
++        TestPattern.enable = 1;
++        TestPattern.pattern = (uint32_t)tpgMode - 1;
++    }
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_TEST_PATTERN, &TestPattern);
++    if (ret != 0)
++    {
++        TRACE(IMX676_ERROR, "%s: set test pattern %d error\n", __func__, tpgMode);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX676_INFO, "%s: test pattern enable[%d] mode[%d]\n", __func__, TestPattern.enable, TestPattern.pattern);
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiFocusSetupIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiFocusReleaseIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiFocusGetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiFocusSetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetFocusCalibrateIss(IsiSensorHandle_t handle, IsiFoucsCalibAttr_t *pFocusCalib)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiGetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t *pExposure)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    if (pIMX676Ctx->AEStartExposure == 0) {
++        pIMX676Ctx->AEStartExposure =
++            (uint64_t)pIMX676Ctx->CurMode.ae_info.start_exposure *
++            pIMX676Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++           
++    }
++    *pExposure =  pIMX676Ctx->AEStartExposure;
++    TRACE(IMX676_INFO, "%s:get start exposure %d\n", __func__, pIMX676Ctx->AEStartExposure);
++
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX676_IsiSetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t exposure)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++    IMX676_Context_t *pIMX676Ctx = (IMX676_Context_t *) handle;
++
++    pIMX676Ctx->AEStartExposure = exposure;
++    TRACE(IMX676_INFO, "set start exposure %d\n", __func__,pIMX676Ctx->AEStartExposure);
++    TRACE(IMX676_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++#endif
++
++RESULT IMX676_IsiGetSensorIss(IsiSensor_t *pIsiSensor)
++{
++    TRACE( IMX676_INFO, "%s (enter)\n", __func__);
++
++    if (pIsiSensor == NULL)
++        return RET_NULL_POINTER;
++     pIsiSensor->pszName                         = SensorName;
++     pIsiSensor->pIsiSensorSetPowerIss           = IMX676_IsiSensorSetPowerIss;
++     pIsiSensor->pIsiCreateSensorIss             = IMX676_IsiCreateSensorIss;
++     pIsiSensor->pIsiReleaseSensorIss            = IMX676_IsiReleaseSensorIss;
++     pIsiSensor->pIsiRegisterReadIss             = IMX676_IsiRegisterReadIss;
++     pIsiSensor->pIsiRegisterWriteIss            = IMX676_IsiRegisterWriteIss;
++     pIsiSensor->pIsiGetSensorModeIss            = IMX676_IsiGetSensorModeIss;
++     pIsiSensor->pIsiSetSensorModeIss            = IMX676_IsiSetSensorModeIss;
++     pIsiSensor->pIsiQuerySensorIss              = IMX676_IsiQuerySensorIss;
++     pIsiSensor->pIsiGetCapsIss                  = IMX676_IsiGetCapsIss;
++     pIsiSensor->pIsiSetupSensorIss              = IMX676_IsiSetupSensorIss;
++     pIsiSensor->pIsiGetSensorRevisionIss        = IMX676_IsiGetSensorRevisionIss;
++     pIsiSensor->pIsiCheckSensorConnectionIss    = IMX676_IsiCheckSensorConnectionIss;
++     pIsiSensor->pIsiSensorSetStreamingIss       = IMX676_IsiSensorSetStreamingIss;
++     pIsiSensor->pIsiGetAeInfoIss                = IMX676_IsiGetAeInfoIss;
++     pIsiSensor->pIsiSetHdrRatioIss              = IMX676_IsiSetHdrRatioIss;
++     pIsiSensor->pIsiGetIntegrationTimeIss       = IMX676_IsiGetIntegrationTimeIss;
++     pIsiSensor->pIsiSetIntegrationTimeIss       = IMX676_IsiSetIntegrationTimeIss;
++     pIsiSensor->pIsiGetGainIss                  = IMX676_IsiGetGainIss;
++     pIsiSensor->pIsiSetGainIss                  = IMX676_IsiSetGainIss;
++     pIsiSensor->pIsiGetSensorFpsIss             = IMX676_IsiGetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorFpsIss             = IMX676_IsiSetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorAfpsLimitsIss      = IMX676_IsiSetSensorAfpsLimitsIss;
++     pIsiSensor->pIsiGetSensorIspStatusIss       = IMX676_IsiGetSensorIspStatusIss;
++#ifndef ISI_LITE
++    pIsiSensor->pIsiSensorSetBlcIss              = IMX676_IsiSensorSetBlcIss;
++    pIsiSensor->pIsiSensorSetWBIss               = IMX676_IsiSensorSetWBIss;
++    pIsiSensor->pIsiSensorGetExpandCurveIss      = IMX676_IsiSensorGetExpandCurveIss;
++    pIsiSensor->pIsiActivateTestPatternIss       = IMX676_IsiSetTestPatternIss;
++    pIsiSensor->pIsiFocusSetupIss                = IMX676_IsiFocusSetupIss;
++    pIsiSensor->pIsiFocusReleaseIss              = IMX676_IsiFocusReleaseIss;
++    pIsiSensor->pIsiFocusSetIss                  = IMX676_IsiFocusSetIss;
++    pIsiSensor->pIsiFocusGetIss                  = IMX676_IsiFocusGetIss;
++    pIsiSensor->pIsiGetFocusCalibrateIss         = IMX676_IsiGetFocusCalibrateIss;
++    pIsiSensor->pIsiSetAeStartExposureIss        = IMX676_IsiSetAeStartExposureIs;
++    pIsiSensor->pIsiGetAeStartExposureIss        = IMX676_IsiGetAeStartExposureIs;
++#endif
++    TRACE( IMX676_INFO, "%s (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++/*****************************************************************************
++* each sensor driver need declare this struct for isi load
++*****************************************************************************/
++IsiCamDrvConfig_t IsiCamDrvConfig = {
++    .CameraDriverID = 0x0676,
++    .pIsiHalQuerySensor = IMX676_IsiHalQuerySensorIss,
++    .pfIsiGetSensorIss = IMX676_IsiGetSensorIss,
++};
+\ No newline at end of file
+diff --git a/units/isi/drv/imx678/CMakeLists.txt b/units/isi/drv/imx678/CMakeLists.txt
+new file mode 100644
+index 0000000..48b5f31
+--- /dev/null
++++ b/units/isi/drv/imx678/CMakeLists.txt
+@@ -0,0 +1,122 @@
++cmake_minimum_required(VERSION 2.6)
++
++# define module name & interface version
++set (module imx678)
++
++# define interface version
++set (${module}_INTERFACE_CURRENT  1)
++set (${module}_INTERFACE_REVISION 0)
++set (${module}_INTERFACE_AGE      0)
++
++# we want to compile all .c files as default
++file(GLOB libsources source/IMX678.c )
++
++# set public headers, these get installed
++file(GLOB pub_headers include/*.h)
++
++# define include paths
++include_directories(
++    include
++    include_priv
++    ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include
++    )
++
++# module specific defines
++###add_definitions(-Wno-error=unused-function)
++
++# add lib to build env
++#add_library(${module}_static STATIC ${libsources})
++add_library(${module}_shared SHARED ${libsources})
++
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES OUTPUT_NAME     ${module})
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES LINK_FLAGS      -static)
++#SET_TARGET_PROPERTIES(${module}_static PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES OUTPUT_NAME     ${module})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES LINK_FLAGS      -shared)
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES SOVERSION       ${${module}_INTERFACE_CURRENT})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES VERSION         ${${module}_INTERFACE_CURRENT}.${${module}_INTERFACE_REVISION}.${${module}_INTERFACE_AGE})
++SET_TARGET_PROPERTIES(${module}_shared PROPERTIES FRAMEWORK       TRUE PUBLIC_HEADER "${pub_headers}")
++
++# add convenience target: put sensor driver into the 'bin' output dir as well
++if ( NOT ANDROID )
++add_custom_target(${module}.drv
++                  ALL
++                  COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${module}.drv
++                  DEPENDS ${module}_shared
++                  COMMENT "Copying ${module} driver module"
++                  )
++endif()
++
++# define lib dependencies
++#target_link_libraries(${module}_static
++#                      ${platform_libs}
++#                      ${base_libs}
++#                      ${drv_libs}
++#                      isi_shared
++#                      )
++
++# add link libs, or dlopen failed on Android
++if (ANDROID)
++if (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${platform_libs}
++                      ${base_libs}
++                      ${drv_libs}
++                      isi_shared
++                      )
++else (GENERATE_PARTITION_BUILD)
++target_link_libraries(${module}_shared
++                      ${android_partial_platform_libs}
++                      ${android_partial_base_libs}
++                      ${android_partial_drv_libs}
++                      isi_shared
++                      )
++add_library(PrebuiltLibs SHARED IMPORTED)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libhal.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libbufferpool.so)
++set_target_properties(PrebuiltLibs PROPERTIES IMPORTED_LOCATION ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/libcameric_drv.so)
++target_link_libraries(${module}_shared PRIVATE PrebuiltLibs)
++endif (GENERATE_PARTITION_BUILD)
++endif (ANDROID)
++
++# define stuff to install
++#install(TARGETS ${module}_static
++#        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++#        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
++#        )
++
++install(TARGETS ${module}_shared
++        PUBLIC_HEADER   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${module}
++        ARCHIVE         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        LIBRARY         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${module}
++        )
++
++# install the sensor driver as well, but to 'bin' location!
++install(FILES       ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so.${${module}_INTERFACE_CURRENT}
++        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++        RENAME      ${module}.drv
++        )
++
++if( DEFINED APPSHELL_TOP_COMPILE)
++add_custom_target(copy_shell_libs_${module} ALL
++       COMMENT "##Copy libs to shell libs"
++       COMMAND ${CMAKE_COMMAND} -E copy ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/lib/lib${module}.so ${CMAKE_HOME_DIRECTORY}/shell_libs/ispcore/${PLATFORM}/lib${module}.so
++       #COMMAND ${CMAKE_COMMAND} -E copy_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/${module} ${CMAKE_HOME_DIRECTORY}/shell_libs/include/units_headers/${module}
++)
++add_dependencies(copy_shell_libs_${module} ${module}_shared)
++endif( DEFINED APPSHELL_TOP_COMPILE)
++
++if (NOT GENERATE_PARTITION_BUILD)
++add_custom_target(${module}_create_isi_dir
++                  COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/include/isi
++                  COMMENT "Create isi dir for ${module}")
++add_dependencies(${module}_create_isi_dir ${module}_shared)
++endif (NOT GENERATE_PARTITION_BUILD)
++
++unset(HEADER_CP_VAR)
++# create common targets for this module
++include(${UNITS_TOP_DIRECTORY}/targets.cmake)
++
++# create calib data targets
++add_subdirectory(calib)
+\ No newline at end of file
+diff --git a/units/isi/drv/imx678/Sensor0_Entry.cfg b/units/isi/drv/imx678/Sensor0_Entry.cfg
+new file mode 100644
+index 0000000..17fb38c
+--- /dev/null
++++ b/units/isi/drv/imx678/Sensor0_Entry.cfg
+@@ -0,0 +1,9 @@
++name = "imx678"
++drv = "imx678.drv"
++mode = 0
++[mode.0]
++xml = "IMX678_Basic_3840x2160.xml"
++dwe = "dewarp_config/sensor_dwe_IMX678_Basic_3840x2160.json"
++[mode.1]
++xml = "IMX678_Basic_1920x1080.xml"
++dwe = "dewarp_config/sensor_dwe_IMX678_Basic_1920x1080.json"
+diff --git a/units/isi/drv/imx678/Sensor1_Entry.cfg b/units/isi/drv/imx678/Sensor1_Entry.cfg
+new file mode 100644
+index 0000000..57ff057
+--- /dev/null
++++ b/units/isi/drv/imx678/Sensor1_Entry.cfg
+@@ -0,0 +1,9 @@
++name = "imx678"
++drv = "imx678.drv"
++mode = 0
++[mode.0]
++xml = "IMX678_3840x2160.xml"
++dwe = "dewarp_config/sensor_dwe_4K_config.json"
++[mode.1]
++xml = "IMX678_1920x1080.xml"
++dwe = "dewarp_config/sensor_dwe_4K_config.json"
+\ No newline at end of file
+diff --git a/units/isi/drv/imx678/calib/CMakeLists.txt b/units/isi/drv/imx678/calib/CMakeLists.txt
+new file mode 100644
+index 0000000..12d0cb6
+--- /dev/null
++++ b/units/isi/drv/imx678/calib/CMakeLists.txt
+@@ -0,0 +1,42 @@
++cmake_minimum_required(VERSION 2.6)
++
++# use upper level module name
++
++# get calib data filenames
++file(GLOB_RECURSE calib_files *.xml)
++list(SORT calib_files)
++
++# a nice helper function
++function(add_calib_target ${calib_file})
++    # get calib data file's base name
++    get_filename_component(base_name ${calib_file} NAME_WE)
++
++    # add target to put sensor driver calibration data file into the 'bin' output and create a similar named symlink to the driver as well
++    add_custom_target(${base_name}_calib
++                      ALL
++                      COMMAND ${CMAKE_COMMAND} -E copy ${calib_file} ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.xml
++                      #COMMAND ${CMAKE_COMMAND} -E create_symlink ${module}.drv ${LIB_ROOT}/${CMAKE_BUILD_TYPE}/bin/${base_name}.drv
++                      DEPENDS ${calib_file}
++                      COMMENT "Configuring ${base_name} calibration database"
++                      )
++
++#    add_dependencies(${module}_static
++#                     ${base_name}_calib
++#                     )
++
++    add_dependencies(${module}_shared
++                     ${base_name}_calib
++                     )
++
++    # install the sensor driver config & similar named driver symlink as well, but to 'bin' location!
++    install(FILES       ${calib_file}
++            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++            RENAME      ${base_name}.xml
++            )
++    install(CODE "${CMAKE_COMMAND} -E create_symlink ${module}.drv ${CMAKE_INSTALL_PREFIX}/bin/${base_name}.drv")
++endfunction(add_calib_target)
++
++# loop over all calib data files
++foreach(calib_file ${calib_files})
++    add_calib_target(calib_file)
++endforeach(calib_file)
+\ No newline at end of file
+diff --git a/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_1920x1080.xml b/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_1920x1080.xml
+new file mode 100644
+index 0000000..da65a7a
+--- /dev/null
++++ b/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_1920x1080.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX678
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 37]">
++         Basic_1920x1080
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 1920]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 1080]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  1920x1080
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  1920x1080
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.350821 0.461451 0.18773]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.747621 0.0895615 0.658059 0.328222 -0.81157 0.48335]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.840503 -0.541807 -2.5476]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.20944 1.25673 1.30402 1.35132 1.39861 1.4459 1.4932 1.54049 1.58778 1.63508 1.68237 1.72966 1.77696 1.82425 1.87154 1.9188]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.01049 0.0067139 0.00344454 0.000598565 -0.0017099 -0.00358594 -0.00493888 -0.00576626 -0.0060659 -0.00582415 -0.00500751 -0.00359477 -0.00162514 0.000989081 0.00422767 0.010466]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.20944 1.25673 1.30402 1.35132 1.39861 1.4459 1.4932 1.54049 1.58778 1.63508 1.68237 1.72966 1.77696 1.82425 1.87154 1.9188]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.000490041 0.0032861 0.00655546 0.00940144 0.0117099 0.0135859 0.0149389 0.0157663 0.0160659 0.0158242 0.0150075 0.0135948 0.0116251 0.00901092 0.00577233 -0.00046563]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.877256 0.954511 1.03177 1.10902 1.18628 1.26353 1.34079 1.41805 1.4953 1.57256 1.64981 1.72707 1.80432 1.88158 1.9588]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.155026 0.143403 0.132925 0.123335 0.114897 0.107527 0.101224 0.0961947 0.09238 0.0900132 0.0889725 0.0893575 0.091282 0.0947975 0.100008 0.11196]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.877256 0.954511 1.03177 1.10902 1.18628 1.26353 1.34079 1.41805 1.4953 1.57256 1.64981 1.72707 1.80432 1.88158 1.9588]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0449741 0.0565967 0.0670752 0.0766648 0.0851034 0.0924732 0.0987762 0.103805 0.10762 0.109987 0.111027 0.110643 0.108718 0.105203 0.099992 0.088042]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.2094]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9188]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.9588]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.6351]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [2651.53 3387.15 3387.15 7258.5713]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 443.7393]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0306101 -0.0036106]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        1920x1080_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.23923 1 1 2.7836]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.58915 0.0377625 -0.616429 -0.945174 2.52794 -0.537235 -0.217771 -1.76346 2.9884]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-36.4461 -38.1612 -29.3263]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_104
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [533.326 -38.9322 -38.9322 2476.1192]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 182.7902]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.145974 -0.0036106]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1920x1080_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.98523 1 1 1.6928]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.1243 -0.955239 -0.160056 -0.585798 2.27098 -0.616837 -0.0192654 -0.974804 2.036]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-36.8576 -44.6401 -45.1663]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_109
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [797.808 508.94 508.94 2977.8141]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 231.5529]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0300834 -0.019091]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        1920x1080
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        1920x1080_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.48927 1 1 2.4188]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.05797 -0.842641 -0.197003 -0.842204 2.361 -0.441285 -0.076882 -1.19612 2.2813]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-32.4424 -44.2278 -33.9074]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_108
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1920x1080_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [120 120 120 120 120 120 120 120]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [67 67 67 67 68 68 68 68]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1920x1080_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [120 120 120 120 120 120 120 120]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [67 67 67 67 68 68 68 68]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               1920x1080_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [120 120 120 120 120 120 120 120]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [67 67 67 67 68 68 68 68]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               1920x1080_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [120 120 120 120 120 120 120 120]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [67 67 67 67 68 68 68 68]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_104
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 104]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.58915 0.0377625 -0.616429 -0.945174 2.52794 -0.537235 -0.217771 -1.76346 2.9884]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-36.4461 -38.1612 -29.3263]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.23923 1 1 2.7836]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_109
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 109]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.1243 -0.955239 -0.160056 -0.585798 2.27098 -0.616837 -0.0192654 -0.974804 2.036]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-36.8576 -44.6401 -45.1663]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.98523 1 1 1.6928]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_108
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 108]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.05797 -0.842641 -0.197003 -0.842204 2.361 -0.441285 -0.076882 -1.19612 2.2813]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-32.4424 -44.2278 -33.9074]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.48927 1 1 2.4188]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_108
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 108]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.64855 -1.46973 -0.171784 -0.746979 2.12541 -0.309928 -0.0672896 -1.22039 2.3223]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.8121 -42.8676 -35.6405]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.67897 1 1 2.4837]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  1920x1080_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [200 200 200 200]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               1920x1080
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               1920x1080
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_3840x2160.xml b/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_3840x2160.xml
+new file mode 100644
+index 0000000..aaa3e08
+--- /dev/null
++++ b/units/isi/drv/imx678/calib/IMX678/IMX678_Basic_3840x2160.xml
+@@ -0,0 +1,1103 @@
++<?xml version="1.0" ?>
++<matfile>
++   <header type="struct" size="[1 1]">
++      <creation_date index="1" type="char" size="[1 11]">
++         18-Jan-2024
++      </creation_date>
++      <creator index="1" type="char" size="[1 6]">
++         Framos
++      </creator>
++      <sensor_name index="1" type="char" size="[1 6]">
++         IMX678
++      </sensor_name>
++      <sample_name index="1" type="char" size="[1 37]">
++         Basic_3840x2160
++      </sample_name>
++      <generator_version index="1" type="char" size="[1 7]">
++         v2.0.19
++      </generator_version>
++      <resolution index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <id index="1" type="char" size="[1 10]">
++               0x00000001
++            </id>
++            <width index="1" type="double" size="[1 1]">
++               [ 3840]
++            </width>
++            <height index="1" type="double" size="[1 1]">
++               [ 2160]
++            </height>
++            <framerate index="1" type="cell" size="[1 3]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_15
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 14.9916]
++                  </fps>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_10
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 9.9944]
++                  </fps>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 6]">
++                     FPS_05
++                  </name>
++                  <fps index="1" type="double" size="[1 1]">
++                     [ 4.9972]
++                  </fps>
++               </cell>
++            </framerate>
++         </cell>
++      </resolution>
++   </header>
++   <sensor type="struct" size="[1 1]">
++      <AWB index="1" type="struct" size="[1 1]">
++         <globals index="1" type="cell" size="[1 1]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 9]">
++                  3840x2160
++               </name>
++               <resolution index="1" type="char" size="[1 9]">
++                  3840x2160
++               </resolution>
++               <SVDMeanValue index="1" type="double" size="[1 3]">
++                  [0.350821 0.461451 0.18773]
++               </SVDMeanValue>
++               <PCAMatrix index="1" type="double" size="[3 2]">
++                  [-0.747621 0.0895615 0.658059 0.328222 -0.81157 0.48335]
++               </PCAMatrix>
++               <CenterLine index="1" type="double" size="[1 3]">
++                  [-0.840503 -0.541807 -2.5476]
++               </CenterLine>
++               <afRg2 index="1" type="double" size="[1 16]">
++                  [1.20944 1.25673 1.30402 1.35132 1.39861 1.4459 1.4932 1.54049 1.58778 1.63508 1.68237 1.72966 1.77696 1.82425 1.87154 1.9188]
++               </afRg2>
++               <afMaxDist2 index="1" type="double" size="[1 16]">
++                  [0.01049 0.0067139 0.00344454 0.000598565 -0.0017099 -0.00358594 -0.00493888 -0.00576626 -0.0060659 -0.00582415 -0.00500751 -0.00359477 -0.00162514 0.000989081 0.00422767 0.010466]
++               </afMaxDist2>
++               <afRg1 index="1" type="double" size="[1 16]">
++                  [1.20944 1.25673 1.30402 1.35132 1.39861 1.4459 1.4932 1.54049 1.58778 1.63508 1.68237 1.72966 1.77696 1.82425 1.87154 1.9188]
++               </afRg1>
++               <afMaxDist1 index="1" type="double" size="[1 16]">
++                  [-0.000490041 0.0032861 0.00655546 0.00940144 0.0117099 0.0135859 0.0149389 0.0157663 0.0160659 0.0158242 0.0150075 0.0135948 0.0116251 0.00901092 0.00577233 -0.00046563]
++               </afMaxDist1>
++               <afGlobalFade2 index="1" type="double" size="[1 16]">
++                  [0.8 0.877256 0.954511 1.03177 1.10902 1.18628 1.26353 1.34079 1.41805 1.4953 1.57256 1.64981 1.72707 1.80432 1.88158 1.9588]
++               </afGlobalFade2>
++               <afGlobalGainDistance2 index="1" type="double" size="[1 16]">
++                  [0.155026 0.143403 0.132925 0.123335 0.114897 0.107527 0.101224 0.0961947 0.09238 0.0900132 0.0889725 0.0893575 0.091282 0.0947975 0.100008 0.11196]
++               </afGlobalGainDistance2>
++               <afGlobalFade1 index="1" type="double" size="[1 16]">
++                  [0.8 0.877256 0.954511 1.03177 1.10902 1.18628 1.26353 1.34079 1.41805 1.4953 1.57256 1.64981 1.72707 1.80432 1.88158 1.9588]
++               </afGlobalFade1>
++               <afGlobalGainDistance1 index="1" type="double" size="[1 16]">
++                  [0.0449741 0.0565967 0.0670752 0.0766648 0.0851034 0.0924732 0.0987762 0.103805 0.10762 0.109987 0.111027 0.110643 0.108718 0.105203 0.099992 0.088042]
++               </afGlobalGainDistance1>
++               <fRgProjIndoorMin index="1" type="double" size="[1 1]">
++                  [ 1.2094]
++               </fRgProjIndoorMin>
++               <fRgProjMax index="1" type="double" size="[1 1]">
++                  [ 1.9188]
++               </fRgProjMax>
++               <fRgProjMaxSky index="1" type="double" size="[1 1]">
++                  [ 1.9588]
++               </fRgProjMaxSky>
++               <fRgProjOutdoorMin index="1" type="double" size="[1 1]">
++                  [ 1.6351]
++               </fRgProjOutdoorMin>
++               <awb_clip_outdoor index="1" type="char" size="[1 3]">
++                  D65
++               </awb_clip_outdoor>
++               <K_Factor index="1" type="double" size="[1 1]">
++                  [ 4.5676]
++               </K_Factor>
++               <afFade2 index="1" type="double" size="[1 6]">
++                  [0.75 1.28836 1.77672 2.164 2.6 3.0618]
++               </afFade2>
++               <afCbMinRegionMax index="1" type="double" size="[1 6]">
++                  [114 114 105 95 95 90]
++               </afCbMinRegionMax>
++               <afCrMinRegionMax index="1" type="double" size="[1 6]">
++                  [83 83 110 120 122 128]
++               </afCrMinRegionMax>
++               <afMaxCSumRegionMax index="1" type="double" size="[1 6]">
++                  [28 27 18 16 9 9]
++               </afMaxCSumRegionMax>
++               <afCbMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 120]
++               </afCbMinRegionMin>
++               <afCrMinRegionMin index="1" type="double" size="[1 6]">
++                  [123 123 123 123 123 126]
++               </afCrMinRegionMin>
++               <afMaxCSumRegionMin index="1" type="double" size="[1 6]">
++                  [5 5 5 5 5 5]
++               </afMaxCSumRegionMin>
++               <RegionSize index="1" type="double" size="[1 1]">
++                  [ 1]
++               </RegionSize>
++               <RegionSizeInc index="1" type="double" size="[1 1]">
++                  [ 0.8]
++               </RegionSizeInc>
++               <RegionSizeDec index="1" type="double" size="[1 1]">
++                  [ 0.05]
++               </RegionSizeDec>
++               <IIR index="1" type="struct" size="[1 1]">
++                  <DampCoefAdd index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefAdd>
++                  <DampCoefSub index="1" type="double" size="[1 1]">
++                     [ 0.05]
++                  </DampCoefSub>
++                  <DampFilterThreshold index="1" type="double" size="[1 1]">
++                     [ 0.4]
++                  </DampFilterThreshold>
++                  <DampingCoefMin index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefMin>
++                  <DampingCoefMax index="1" type="double" size="[1 1]">
++                     [ 0.9]
++                  </DampingCoefMax>
++                  <DampingCoefInit index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </DampingCoefInit>
++                  <ExpPriorFilterSizeMax index="1" type="double" size="[1 1]">
++                     [ 50]
++                  </ExpPriorFilterSizeMax>
++                  <ExpPriorFilterSizeMin index="1" type="double" size="[1 1]">
++                     [ 1]
++                  </ExpPriorFilterSizeMin>
++                  <ExpPriorMiddle index="1" type="double" size="[1 1]">
++                     [ 0.5]
++                  </ExpPriorMiddle>
++               </IIR>
++            </cell>
++         </globals>
++         <illumination index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 1]">
++                  A
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [2651.53 3387.15 3387.15 7258.5713]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 443.7393]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [-0.0306101 -0.0036106]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3840x2160
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 15]">
++                        3840x2160_A_100
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.23923 1 1 2.7836]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [1.58915 0.0377625 -0.616429 -0.945174 2.52794 -0.537235 -0.217771 -1.76346 2.9884]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-36.4461 -38.1612 -29.3263]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 5]">
++                     A_104
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 3]">
++                  D65
++               </name>
++               <doorType index="1" type="char" size="[1 7]">
++                  Outdoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [533.326 -38.9322 -38.9322 2476.1192]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 182.7902]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [1 1]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.145974 -0.0036106]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3840x2160
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3840x2160_D65_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.98523 1 1 1.6928]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.1243 -0.955239 -0.160056 -0.585798 2.27098 -0.616837 -0.0192654 -0.974804 2.036]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-36.8576 -44.6401 -45.1663]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     D65_109
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 10]">
++                  F11 (TL84)
++               </name>
++               <doorType index="1" type="char" size="[1 6]">
++                  Indoor
++               </doorType>
++               <GMM index="1" type="struct" size="[1 1]">
++                  <invCovMatrix index="1" type="double" size="[2 2]">
++                     [797.808 508.94 508.94 2977.8141]
++                  </invCovMatrix>
++                  <GaussianScalingFactor index="1" type="double" size="[1 1]">
++                     [ 231.5529]
++                  </GaussianScalingFactor>
++                  <tau index="1" type="double" size="[1 2]">
++                     [0.75 0.9]
++                  </tau>
++                  <GaussianMeanValue index="1" type="double" size="[1 2]">
++                     [0.0300834 -0.019091]
++                  </GaussianMeanValue>
++               </GMM>
++               <aLSC index="1" type="cell" size="[1 1]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <resolution index="1" type="char" size="[1 9]">
++                        3840x2160
++                     </resolution>
++                     <LSC_PROFILE_LIST index="1" type="char" size="[1 16]">
++                        3840x2160_F11_90
++                     </LSC_PROFILE_LIST>
++                  </cell>
++               </aLSC>
++               <manualWB index="1" type="double" size="[1 4]">
++                  [1.48927 1 1 2.4188]
++               </manualWB>
++               <manualccMatrix index="1" type="double" size="[3 3]">
++                  [2.05797 -0.842641 -0.197003 -0.842204 2.361 -0.441285 -0.076882 -1.19612 2.2813]
++               </manualccMatrix>
++               <manualccOffsets index="1" type="double" size="[1 3]">
++                  [-32.4424 -44.2278 -33.9074]
++               </manualccOffsets>
++               <awbType index="1" type="char" size="[1 4]">
++                  AUTO
++               </awbType>
++               <sat_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <sat index="1" type="double" size="[1 4]">
++                     [100 95 90 74]
++                  </sat>
++               </sat_CT>
++               <vig_CT index="1" type="struct" size="[1 1]">
++                  <gains index="1" type="double" size="[1 4]">
++                     [1 2 4 8]
++                  </gains>
++                  <vig index="1" type="double" size="[1 4]">
++                     [100 95 90 70]
++                  </vig>
++               </vig_CT>
++               <aCC index="1" type="struct" size="[1 1]">
++                  <CC_PROFILE_LIST index="1" type="char" size="[1 7]">
++                     F11_108
++                  </CC_PROFILE_LIST>
++               </aCC>
++            </cell>
++         </illumination>
++      </AWB>
++      <LSC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3840x2160_A_100
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <illumination index="1" type="char" size="[1 1]">
++               A
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [240 240 240 240 240 240 240 240]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [135 135 135 135 135 135 135 135]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 100]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3840x2160_D65_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               D65
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [240 240 240 240 240 240 240 240]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [135 135 135 135 135 135 135 135]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 16]">
++               3840x2160_F11_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <illumination index="1" type="char" size="[1 3]">
++               F11
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [240 240 240 240 240 240 240 240]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [135 135 135 135 135 135 135 135]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 15]">
++               3840x2160_F2_90
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <illumination index="1" type="char" size="[1 2]">
++               F2
++            </illumination>
++            <LSC_sectors index="1" type="double" size="[1 1]">
++               [ 16]
++            </LSC_sectors>
++            <LSC_No index="1" type="double" size="[1 1]">
++               [ 10]
++            </LSC_No>
++            <LSC_Xo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Xo>
++            <LSC_Yo index="1" type="double" size="[1 1]">
++               [ 15]
++            </LSC_Yo>
++            <LSC_SECT_SIZE_X index="1" type="double" size="[1 8]">
++               [240 240 240 240 240 240 240 240]
++            </LSC_SECT_SIZE_X>
++            <LSC_SECT_SIZE_Y index="1" type="double" size="[1 8]">
++               [135 135 135 135 135 135 135 135]
++            </LSC_SECT_SIZE_Y>
++            <vignetting index="1" type="double" size="[1 1]">
++               [ 90]
++            </vignetting>
++            <LSC_SAMPLES_red index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_red>
++            <LSC_SAMPLES_greenR index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenR>
++            <LSC_SAMPLES_greenB index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_greenB>
++            <LSC_SAMPLES_blue index="1" type="double" size="[17 17]">
++               [1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024 1024]
++            </LSC_SAMPLES_blue>
++         </cell>
++      </LSC>
++      <CC index="1" type="cell" size="[1 4]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 5]">
++               A_104
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 104]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [1.58915 0.0377625 -0.616429 -0.945174 2.52794 -0.537235 -0.217771 -1.76346 2.9884]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-36.4461 -38.1612 -29.3263]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.23923 1 1 2.7836]
++            </wb>
++         </cell>
++         <cell index="2" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               D65_109
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 109]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.1243 -0.955239 -0.160056 -0.585798 2.27098 -0.616837 -0.0192654 -0.974804 2.036]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-36.8576 -44.6401 -45.1663]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.98523 1 1 1.6928]
++            </wb>
++         </cell>
++         <cell index="3" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 7]">
++               F11_108
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 108]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.05797 -0.842641 -0.197003 -0.842204 2.361 -0.441285 -0.076882 -1.19612 2.2813]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-32.4424 -44.2278 -33.9074]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.48927 1 1 2.4188]
++            </wb>
++         </cell>
++         <cell index="4" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               F2_108
++            </name>
++            <saturation index="1" type="double" size="[1 1]">
++               [ 108]
++            </saturation>
++            <ccMatrix index="1" type="double" size="[3 3]">
++               [2.64855 -1.46973 -0.171784 -0.746979 2.12541 -0.309928 -0.0672896 -1.22039 2.3223]
++            </ccMatrix>
++            <ccOffsets index="1" type="double" size="[1 3]">
++               [-28.8121 -42.8676 -35.6405]
++            </ccOffsets>
++            <wb index="1" type="double" size="[1 4]">
++               [1.67897 1 1 2.4837]
++            </wb>
++         </cell>
++      </CC>
++      <AF index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++      </AF>
++      <AEC index="1" type="struct" size="[1 1]">
++         <SetPoint index="1" type="double" size="[1 1]">
++            [ 80]
++         </SetPoint>
++         <ClmTolerance index="1" type="double" size="[1 1]">
++            [ 20]
++         </ClmTolerance>
++         <DampOver index="1" type="double" size="[1 1]">
++            [ 0.2]
++         </DampOver>
++         <DampUnder index="1" type="double" size="[1 1]">
++            [ 0.3]
++         </DampUnder>
++         <DampOverVideo index="1" type="double" size="[1 1]">
++            [ 0.7]
++         </DampOverVideo>
++         <DampUnderVideo index="1" type="double" size="[1 1]">
++            [ 0.9]
++         </DampUnderVideo>
++         <ECM index="1" type="cell" size="[1 3]">
++            <cell index="1" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3840x2160_FPS_15
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="2" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3840x2160_FPS_10
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++            <cell index="3" type="struct" size="[1 1]">
++               <name index="1" type="char" size="[1 16]">
++                  3840x2160_FPS_05
++               </name>
++               <PrioritySchemes index="1" type="cell" size="[1 3]">
++                  <cell index="1" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        fast
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 1]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="2" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 6]">
++                        normal
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 2]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++                  <cell index="3" type="struct" size="[1 1]">
++                     <name index="1" type="char" size="[1 4]">
++                        slow
++                     </name>
++                     <OffsetT0Fac index="1" type="double" size="[1 1]">
++                        [ 4]
++                     </OffsetT0Fac>
++                     <SlopeA0 index="1" type="double" size="[1 1]">
++                        [ 0.9]
++                     </SlopeA0>
++                  </cell>
++               </PrioritySchemes>
++            </cell>
++         </ECM>
++         <aFpsMaxGain index="1" type="double" size="[1 1]">
++            [ 8]
++         </aFpsMaxGain>
++      </AEC>
++      <BLS index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <blsData index="1" type="double" size="[1 4]">
++               [50 50 50 50]
++            </blsData>
++         </cell>
++      </BLS>
++      <DEGAMMA index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 6]">
++               linear
++            </name>
++            <degamma_dx index="1" type="double" size="[1 16]">
++               [256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4096]
++            </degamma_dx>
++            <degamma_y index="1" type="double" size="[1 17]">
++               [0 256 512 768 1024 1280 1536 1792 2048 2304 2560 2816 3072 3328 3584 3840 4095]
++            </degamma_y>
++         </cell>
++      </DEGAMMA>
++      <WDR index="1" type="struct" size="[1 1]">
++         <tbd index="1" type="double" size="[1 1]">
++            [ -1]
++         </tbd>
++         <curve1 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve1>
++         <curve2 index="1" type="struct" size="[1 1]">
++            <xval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </xval>
++            <yval index="1" type="double" size="[1 33]">
++               [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
++            </yval>
++         </curve2>
++      </WDR>
++      <CAC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <x_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normshift>
++            <x_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_normfactor>
++            <y_normshift index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normshift>
++            <y_normfactor index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_normfactor>
++            <x_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </x_offset>
++            <y_offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </y_offset>
++            <red_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </red_parameters>
++            <blue_parameters index="1" type="double" size="[1 3]">
++               [0 0 0]
++            </blue_parameters>
++         </cell>
++      </CAC>
++      <DPF index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <NLL_SEGMENTATION index="1" type="double" size="[1 1]">
++               [ 1]
++            </NLL_SEGMENTATION>
++            <nll_coeff_n index="1" type="double" size="[1 17]">
++               [1023 859 589 476 410 334 288 258 235 203 182 166 143 128 117 108 101]
++            </nll_coeff_n>
++            <SigmaGreen index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaGreen>
++            <SigmaRedBlue index="1" type="double" size="[1 1]">
++               [ 4]
++            </SigmaRedBlue>
++            <Gradient index="1" type="double" size="[1 1]">
++               [ 0.15]
++            </Gradient>
++            <Offset index="1" type="double" size="[1 1]">
++               [ 0]
++            </Offset>
++            <NlGains index="1" type="double" size="[1 4]">
++               [1 1 1 1]
++            </NlGains>
++         </cell>
++      </DPF>
++      <DPCC index="1" type="cell" size="[1 1]">
++         <cell index="1" type="struct" size="[1 1]">
++            <name index="1" type="char" size="[1 9]">
++               3840x2160
++            </name>
++            <resolution index="1" type="char" size="[1 9]">
++               3840x2160
++            </resolution>
++            <register index="1" type="cell" size="[1 23]">
++               <cell index="1" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 13]">
++                     ISP_DPCC_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0004
++                  </value>
++               </cell>
++               <cell index="2" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_OUT_MODE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0003
++                  </value>
++               </cell>
++               <cell index="3" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 16]">
++                     ISP_DPCC_SET_USE
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0007
++                  </value>
++               </cell>
++               <cell index="4" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1D1D
++                  </value>
++               </cell>
++               <cell index="5" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0707
++                  </value>
++               </cell>
++               <cell index="6" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_METHODS_SET3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1F1F
++                  </value>
++               </cell>
++               <cell index="7" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="8" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="9" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="10" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="11" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_1
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="12" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x100C
++                  </value>
++               </cell>
++               <cell index="13" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x1810
++                  </value>
++               </cell>
++               <cell index="14" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="15" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="16" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_2
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0808
++                  </value>
++               </cell>
++               <cell index="17" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 22]">
++                     ISP_DPCC_LINE_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x2020
++                  </value>
++               </cell>
++               <cell index="18" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 23]">
++                     ISP_DPCC_LINE_MAD_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="19" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_PG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0403
++                  </value>
++               </cell>
++               <cell index="20" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 21]">
++                     ISP_DPCC_RND_THRESH_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0806
++                  </value>
++               </cell>
++               <cell index="21" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RG_FAC_3
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0404
++                  </value>
++               </cell>
++               <cell index="22" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 18]">
++                     ISP_DPCC_RO_LIMITS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0A0A
++                  </value>
++               </cell>
++               <cell index="23" type="struct" size="[1 1]">
++                  <name index="1" type="char" size="[1 17]">
++                     ISP_DPCC_RND_OFFS
++                  </name>
++                  <value index="1" type="char" size="[1 6]">
++                     0x0FFF
++                  </value>
++               </cell>
++            </register>
++         </cell>
++      </DPCC>
++   </sensor>
++   <system type="struct" size="[1 1]">
++      <AFPS index="1" type="struct" size="[1 1]">
++         <aFpsDefault index="1" type="char" size="[1 2]">
++            on
++         </aFpsDefault>
++      </AFPS>
++   </system>
++<tuning>
++      <awb enable="true">
++         <damping>true</damping>
++         <index>2</index>
++         <mode>2</mode>
++      </awb>
++   </tuning>
++</matfile>
+\ No newline at end of file
+diff --git a/units/isi/drv/imx678/source/IMX678.c b/units/isi/drv/imx678/source/IMX678.c
+new file mode 100644
+index 0000000..b2d35da
+--- /dev/null
++++ b/units/isi/drv/imx678/source/IMX678.c
+@@ -0,0 +1,1268 @@
++/******************************************************************************\
++|* Copyright (c) 2020 by VeriSilicon Holdings Co., Ltd. ("VeriSilicon")       *|
++|* All Rights Reserved.                                                       *|
++|*                                                                            *|
++|* The material in this file is confidential and contains trade secrets of    *|
++|* of VeriSilicon.  This is proprietary information owned or licensed by      *|
++|* VeriSilicon.  No part of this work may be disclosed, reproduced, copied,   *|
++|* transmitted, or used in any way for any purpose, without the express       *|
++|* written permission of VeriSilicon.                                         *|
++|*                                                                            *|
++\******************************************************************************/
++
++#include <ebase/types.h>
++#include <ebase/trace.h>
++#include <ebase/builtins.h>
++#include <common/return_codes.h>
++#include <common/misc.h>
++#include <sys/ioctl.h>
++#include <fcntl.h>
++#include "isi.h"
++#include "isi_iss.h"
++#include "isi_priv.h"
++#include "vvsensor.h"
++
++CREATE_TRACER( IMX678_INFO , "IMX678: ", INFO,    1);
++CREATE_TRACER( IMX678_WARN , "IMX678: ", WARNING, 1);
++CREATE_TRACER( IMX678_ERROR, "IMX678: ", ERROR,   1);
++
++#ifdef SUBDEV_V4L2
++#include <sys/ioctl.h>
++#include <sys/mman.h>
++#include <fcntl.h>
++#include <linux/videodev2.h>
++#include <linux/v4l2-subdev.h>
++//#undef TRACE
++//#define TRACE(x, ...)
++#endif
++
++static const char SensorName[16] = "imx678";
++
++typedef struct IMX678_Context_s
++{
++    IsiSensorContext_t  IsiCtx;
++    struct vvcam_mode_info_s CurMode;
++    IsiSensorAeInfo_t AeInfo;
++    IsiSensorIntTime_t IntTime;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    IsiSensorGain_t SensorGain;
++    uint32_t minAfps;
++    uint64_t AEStartExposure;
++} IMX678_Context_t;
++
++static RESULT IMX678_IsiSensorSetPowerIss(IsiSensorHandle_t handle, bool_t on)
++{
++    int ret = 0;
++
++    TRACE( IMX678_INFO, "%s: (enter)\n", __func__);
++    TRACE( IMX678_INFO, "%s: set power %d\n", __func__,on);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    int32_t power = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_POWER, &power);
++    if (ret != 0){
++        TRACE(IMX678_ERROR, "%s set power %d error\n", __func__,power);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorGetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (!pclk)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CLK, pclk);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s get clock error\n", __func__);
++        return RET_FAILURE;
++    } 
++    
++    TRACE( IMX678_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++    TRACE( IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorSetClkIss(IsiSensorHandle_t handle,
++                                        struct vvcam_clk_s *pclk)
++{
++    int ret = 0;
++
++    TRACE( IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pclk == NULL)
++        return RET_NULL_POINTER;
++    
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_CLK, &pclk);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX678_INFO, "%s: status:%d sensor_mclk:%d csi_max_pixel_clk:%d\n",
++        __func__, pclk->status, pclk->sensor_mclk, pclk->csi_max_pixel_clk);
++
++    TRACE( IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiResetSensorIss(IsiSensorHandle_t handle)
++{
++    int ret = 0;
++
++    TRACE( IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_RESET, NULL);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s set reset error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE( IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiRegisterReadIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        uint32_t * pValue)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_READ_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: read sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    *pValue = sccb_data.data;
++
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiRegisterWriteIss(IsiSensorHandle_t handle,
++                                        const uint32_t address,
++                                        const uint32_t value)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    struct vvcam_sccb_data_s sccb_data;
++    sccb_data.addr = address;
++    sccb_data.data = value;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_WRITE_REG, &sccb_data);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: write sensor register error!\n", __func__);
++        return (RET_FAILURE);
++    }
++
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_UpdateIsiAEInfo(IsiSensorHandle_t handle)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    IsiSensorAeInfo_t *pAeInfo = &pIMX678Ctx->AeInfo;
++    pAeInfo->oneLineExpTime = pIMX678Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++
++    if (pIMX678Ctx->CurMode.hdr_mode == SENSOR_MODE_LINEAR) {
++        pAeInfo->maxIntTime.linearInt =
++            pIMX678Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->minIntTime.linearInt =
++            pIMX678Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime * 1000;
++        pAeInfo->maxAGain.linearGainParas = pIMX678Ctx->CurMode.ae_info.max_again;
++        pAeInfo->minAGain.linearGainParas = pIMX678Ctx->CurMode.ae_info.min_again;
++        pAeInfo->maxDGain.linearGainParas = pIMX678Ctx->CurMode.ae_info.max_dgain;
++        pAeInfo->minDGain.linearGainParas = pIMX678Ctx->CurMode.ae_info.min_dgain;
++    } else {
++        switch (pIMX678Ctx->CurMode.stitching_mode) {
++            case SENSOR_STITCHING_DUAL_DCG:
++            case SENSOR_STITCHING_3DOL:
++            case SENSOR_STITCHING_LINEBYLINE:
++                pAeInfo->maxIntTime.triInt.triSIntTime =
++                    pIMX678Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triSIntTime =
++                    pIMX678Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                
++                pAeInfo->maxIntTime.triInt.triIntTime =
++                    pIMX678Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.triInt.triIntTime =
++                    pIMX678Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX678Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG) {
++                    pAeInfo->maxIntTime.triInt.triLIntTime = pAeInfo->maxIntTime.triInt.triIntTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime = pAeInfo->minIntTime.triInt.triIntTime;
++                } else {
++                    pAeInfo->maxIntTime.triInt.triLIntTime =
++                        pIMX678Ctx->CurMode.ae_info.max_longintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.triInt.triLIntTime =
++                        pIMX678Ctx->CurMode.ae_info.min_longintegration_line * pAeInfo->oneLineExpTime;
++                }
++
++                pAeInfo->maxAGain.triGainParas.triSGain = pIMX678Ctx->CurMode.ae_info.max_short_again;
++                pAeInfo->minAGain.triGainParas.triSGain = pIMX678Ctx->CurMode.ae_info.min_short_again;
++                pAeInfo->maxDGain.triGainParas.triSGain = pIMX678Ctx->CurMode.ae_info.max_short_dgain;
++                pAeInfo->minDGain.triGainParas.triSGain = pIMX678Ctx->CurMode.ae_info.min_short_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triGain = pIMX678Ctx->CurMode.ae_info.max_again;
++                pAeInfo->minAGain.triGainParas.triGain = pIMX678Ctx->CurMode.ae_info.min_again;
++                pAeInfo->maxDGain.triGainParas.triGain = pIMX678Ctx->CurMode.ae_info.max_dgain;
++                pAeInfo->minDGain.triGainParas.triGain = pIMX678Ctx->CurMode.ae_info.min_dgain;
++
++                pAeInfo->maxAGain.triGainParas.triLGain = pIMX678Ctx->CurMode.ae_info.max_long_again;
++                pAeInfo->minAGain.triGainParas.triLGain = pIMX678Ctx->CurMode.ae_info.min_long_again;
++                pAeInfo->maxDGain.triGainParas.triLGain = pIMX678Ctx->CurMode.ae_info.max_long_dgain;
++                pAeInfo->minDGain.triGainParas.triLGain = pIMX678Ctx->CurMode.ae_info.min_long_dgain;
++                break;
++            case SENSOR_STITCHING_DUAL_DCG_NOWAIT:
++            case SENSOR_STITCHING_16BIT_COMPRESS:
++            case SENSOR_STITCHING_L_AND_S:
++            case SENSOR_STITCHING_2DOL:
++                pAeInfo->maxIntTime.dualInt.dualIntTime =
++                    pIMX678Ctx->CurMode.ae_info.max_integration_line * pAeInfo->oneLineExpTime;
++                pAeInfo->minIntTime.dualInt.dualIntTime =
++                    pIMX678Ctx->CurMode.ae_info.min_integration_line * pAeInfo->oneLineExpTime;
++
++                if (pIMX678Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime = pAeInfo->maxIntTime.dualInt.dualIntTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime = pAeInfo->minIntTime.dualInt.dualIntTime;
++                } else {
++                    pAeInfo->maxIntTime.dualInt.dualSIntTime =
++                        pIMX678Ctx->CurMode.ae_info.max_vsintegration_line * pAeInfo->oneLineExpTime;
++                    pAeInfo->minIntTime.dualInt.dualSIntTime =
++                        pIMX678Ctx->CurMode.ae_info.min_vsintegration_line * pAeInfo->oneLineExpTime;
++                }
++                
++                if (pIMX678Ctx->CurMode.stitching_mode == SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.min_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.max_long_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.min_long_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.max_long_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.min_long_dgain;
++                } else {
++                    pAeInfo->maxAGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.max_short_again;
++                    pAeInfo->minAGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.min_short_again;
++                    pAeInfo->maxDGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.max_short_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualSGain = pIMX678Ctx->CurMode.ae_info.min_short_dgain;
++                    pAeInfo->maxAGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.max_again;
++                    pAeInfo->minAGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.min_again;
++                    pAeInfo->maxDGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.max_dgain;
++                    pAeInfo->minDGain.dualGainParas.dualGain  = pIMX678Ctx->CurMode.ae_info.min_dgain;
++                }
++                
++                break;
++            default:
++                break;
++        }
++    }
++    pAeInfo->gainStep = pIMX678Ctx->CurMode.ae_info.gain_step;
++    pAeInfo->currFps  = pIMX678Ctx->CurMode.ae_info.cur_fps;
++    pAeInfo->maxFps   = pIMX678Ctx->CurMode.ae_info.max_fps;
++    pAeInfo->minFps   = pIMX678Ctx->CurMode.ae_info.min_fps;
++    pAeInfo->minAfps  = pIMX678Ctx->CurMode.ae_info.min_afps;
++    pAeInfo->hdrRatio[0] = pIMX678Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s;
++    pAeInfo->hdrRatio[1] = pIMX678Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs;
++
++    pAeInfo->intUpdateDlyFrm = pIMX678Ctx->CurMode.ae_info.int_update_delay_frm;
++    pAeInfo->gainUpdateDlyFrm = pIMX678Ctx->CurMode.ae_info.gain_update_delay_frm;
++
++    if (pIMX678Ctx->minAfps != 0) {
++        pAeInfo->minAfps = pIMX678Ctx->minAfps;
++    } 
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    memcpy(pMode, &pIMX678Ctx->CurMode, sizeof(IsiSensorMode_t));
++
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetSensorModeIss(IsiSensorHandle_t handle,
++                                         IsiSensorMode_t *pMode)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pMode == NULL)
++        return (RET_NULL_POINTER);
++
++    struct vvcam_mode_info_s sensor_mode;
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    sensor_mode.index = pMode->index;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memset(&sensor_mode, 0, sizeof(struct vvcam_mode_info_s));
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s set sensor mode failed", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX678Ctx->CurMode, &sensor_mode, sizeof(struct vvcam_mode_info_s));
++    IMX678_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorSetStreamingIss(IsiSensorHandle_t handle,
++                                              bool_t on)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    uint32_t status = on;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_STREAM, &status);
++    if (ret != 0){
++        TRACE(IMX678_ERROR, "%s set sensor stream %d error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: set streaming %d\n", __func__, on);
++    TRACE(IMX678_INFO, "%s (exit) \n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiCreateSensorIss(IsiSensorInstanceConfig_t * pConfig)
++{
++    RESULT result = RET_SUCCESS;
++    IMX678_Context_t *pIMX678Ctx;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    if (!pConfig || !pConfig->pSensor || !pConfig->HalHandle)
++        return RET_NULL_POINTER;
++
++    pIMX678Ctx = (IMX678_Context_t *) malloc(sizeof(IMX678_Context_t));
++    if (!pIMX678Ctx)
++        return RET_OUTOFMEM;
++
++    memset(pIMX678Ctx, 0, sizeof(IMX678_Context_t));
++    pIMX678Ctx->IsiCtx.HalHandle = pConfig->HalHandle;
++    pIMX678Ctx->IsiCtx.pSensor   = pConfig->pSensor;
++    pConfig->hSensor = (IsiSensorHandle_t) pIMX678Ctx;
++
++    result = IMX678_IsiSensorSetPowerIss(pIMX678Ctx, BOOL_TRUE);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s set power error\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    result = IMX678_IsiSensorGetClkIss(pIMX678Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s get clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    clk.status = 1;
++    result = IMX678_IsiSensorSetClkIss(pIMX678Ctx, &clk);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s set clk error\n", __func__);
++        return RET_FAILURE;
++    }
++    result = IMX678_IsiResetSensorIss(pIMX678Ctx);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s retset sensor error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    IsiSensorMode_t SensorMode;
++    SensorMode.index = pConfig->SensorModeIndex;
++    result = IMX678_IsiSetSensorModeIss(pIMX678Ctx, &SensorMode);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s set sensor mode error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX678_IsiReleaseSensorIss(IsiSensorHandle_t handle)
++{
++    TRACE(IMX678_INFO, "%s (enter) \n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    if (pIMX678Ctx == NULL)
++        return (RET_WRONG_HANDLE);
++
++    IMX678_IsiSensorSetStreamingIss(pIMX678Ctx, BOOL_FALSE);
++    struct vvcam_clk_s clk;
++    memset(&clk, 0, sizeof(struct vvcam_clk_s));
++    IMX678_IsiSensorGetClkIss(pIMX678Ctx, &clk);
++    clk.status = 0;
++    IMX678_IsiSensorSetClkIss(pIMX678Ctx, &clk);
++    IMX678_IsiSensorSetPowerIss(pIMX678Ctx, BOOL_FALSE);
++    free(pIMX678Ctx);
++    pIMX678Ctx = NULL;
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiHalQuerySensorIss(HalHandle_t HalHandle,
++                                          IsiSensorModeInfoArray_t *pSensorMode)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter) \n", __func__);
++
++    if (HalHandle == NULL || pSensorMode == NULL)
++        return RET_NULL_POINTER;
++
++    HalContext_t *pHalCtx = (HalContext_t *)HalHandle;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_QUERY, pSensorMode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiQuerySensorIss(IsiSensorHandle_t handle,
++                                       IsiSensorModeInfoArray_t *pSensorMode)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX678_INFO, "%s (enter) \n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    result = IMX678_IsiHalQuerySensorIss(pIMX678Ctx->IsiCtx.HalHandle,
++                                         pSensorMode);
++    if (result != RET_SUCCESS)
++        TRACE(IMX678_ERROR, "%s: query sensor mode info error!\n", __func__);
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX678_IsiGetCapsIss(IsiSensorHandle_t handle,
++                                   IsiSensorCaps_t * pIsiSensorCaps)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX678_INFO, "%s (enter) \n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    IsiSensorModeInfoArray_t SensorModeInfo;
++    memset(&SensorModeInfo, 0, sizeof(IsiSensorModeInfoArray_t));
++    result = IMX678_IsiQuerySensorIss(handle, &SensorModeInfo);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s: query sensor mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    pIsiSensorCaps->FieldSelection    = ISI_FIELDSEL_BOTH;
++    pIsiSensorCaps->YCSequence        = ISI_YCSEQ_YCBYCR;
++    pIsiSensorCaps->Conv422           = ISI_CONV422_NOCOSITED;
++    pIsiSensorCaps->HPol              = ISI_HPOL_REFPOS;
++    pIsiSensorCaps->VPol              = ISI_VPOL_NEG;
++    pIsiSensorCaps->Edge              = ISI_EDGE_RISING;
++    pIsiSensorCaps->supportModeNum    = SensorModeInfo.count;
++    pIsiSensorCaps->currentMode       = pIMX678Ctx->CurMode.index;
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return result;
++}
++
++static RESULT IMX678_IsiSetupSensorIss(IsiSensorHandle_t handle,
++                                       const IsiSensorCaps_t *pIsiSensorCaps )
++{
++    int ret = 0;
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pIsiSensorCaps == NULL)
++        return RET_NULL_POINTER;
++
++    if (pIsiSensorCaps->currentMode != pIMX678Ctx->CurMode.index) {
++        IsiSensorMode_t SensorMode;
++        memset(&SensorMode, 0, sizeof(IsiSensorMode_t));
++        SensorMode.index = pIsiSensorCaps->currentMode;
++        result = IMX678_IsiSetSensorModeIss(handle, &SensorMode);
++        if (result != RET_SUCCESS) {
++            TRACE(IMX678_ERROR, "%s:set sensor mode %d failed!\n",
++                  __func__, SensorMode.index);
++            return result;
++        }
++    }
++
++#ifdef SUBDEV_V4L2
++    struct v4l2_subdev_format format;
++    memset(&format, 0, sizeof(struct v4l2_subdev_format));
++    format.format.width  = pIMX678Ctx->CurMode.size.bounds_width;
++    format.format.height = pIMX678Ctx->CurMode.size.bounds_height;
++    format.which = V4L2_SUBDEV_FORMAT_ACTIVE;
++    format.pad = 0;
++    ret = ioctl(pHalCtx->sensor_fd, VIDIOC_SUBDEV_S_FMT, &format);
++    if (ret != 0){
++        TRACE(IMX678_ERROR, "%s: sensor set format error!\n", __func__);
++        return RET_FAILURE;
++    }
++#else
++    ret = ioctrl(pHalCtx->sensor_fd, VVSENSORIOC_S_INIT, NULL);
++    if (ret != 0){
++        TRACE(IMX678_ERROR, "%s: sensor init error!\n", __func__);
++        return RET_FAILURE;
++    }
++#endif
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetSensorRevisionIss(IsiSensorHandle_t handle, uint32_t *pValue)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pValue == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_CHIP_ID, pValue);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: get chip id error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiCheckSensorConnectionIss(IsiSensorHandle_t handle)
++{
++    RESULT result = RET_SUCCESS;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    uint32_t ChipId = 0;
++    result = IMX678_IsiGetSensorRevisionIss(handle, &ChipId);
++    if (result != RET_SUCCESS) {
++        TRACE(IMX678_ERROR, "%s:get sensor chip id error!\n",__func__);
++        return RET_FAILURE;
++    }
++
++    if (ChipId != 678) {
++        TRACE(IMX678_ERROR,
++            "%s:ChipID=678,while read sensor Id=0x%x error!\n",
++             __func__, ChipId);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetAeInfoIss(IsiSensorHandle_t handle,
++                                     IsiSensorAeInfo_t *pAeInfo)
++{
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    if (pAeInfo == NULL)
++        return RET_NULL_POINTER;
++
++    memcpy(pAeInfo, &pIMX678Ctx->AeInfo, sizeof(IsiSensorAeInfo_t));
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetHdrRatioIss(IsiSensorHandle_t handle,
++                                       uint8_t hdrRatioNum,
++                                       uint32_t HdrRatio[])
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    struct sensor_hdr_artio_s hdr_ratio;
++    if (hdrRatioNum == 2) {
++        hdr_ratio.ratio_s_vs = HdrRatio[1];
++        hdr_ratio.ratio_l_s = HdrRatio[0];
++    }else {
++        hdr_ratio.ratio_s_vs = HdrRatio[0];
++        hdr_ratio.ratio_l_s = 0;
++    }
++
++    if (hdr_ratio.ratio_s_vs == pIMX678Ctx->CurMode.ae_info.hdr_ratio.ratio_s_vs &&
++        hdr_ratio.ratio_l_s == pIMX678Ctx->CurMode.ae_info.hdr_ratio.ratio_l_s)
++        return RET_SUCCESS;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_HDR_RADIO, &hdr_ratio);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR,"%s: set hdr ratio error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s sensor_mode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &sensor_mode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR,"%s: get mode info error!\n", __func__);
++        return RET_FAILURE;
++    }
++
++    memcpy(&pIMX678Ctx->CurMode, &sensor_mode, sizeof (struct vvcam_mode_info_s));
++    IMX678_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    memcpy(pIntegrationTime, &pIMX678Ctx->IntTime, sizeof(IsiSensorIntTime_t));
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++
++}
++
++static RESULT IMX678_IsiSetIntegrationTimeIss(IsiSensorHandle_t handle,
++                                   IsiSensorIntTime_t *pIntegrationTime)
++{
++    int ret = 0;
++    uint32_t LongIntLine;
++    uint32_t IntLine;
++    uint32_t ShortIntLine;
++    uint32_t oneLineTime;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++    printf("\n\nAAAAAAAAAAAAAAA %u\n\n", pIntegrationTime->IntegrationTime.linearInt);
++    if (pIntegrationTime == NULL)
++        return RET_NULL_POINTER;
++
++    oneLineTime =  pIMX678Ctx->AeInfo.oneLineExpTime;
++    pIMX678Ctx->IntTime.expoFrmType = pIntegrationTime->expoFrmType;
++
++    switch (pIntegrationTime->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            IntLine = pIntegrationTime->IntegrationTime.linearInt;
++            if (IntLine != pIMX678Ctx->IntLine) {
++                printf("\n\ngoing into S_EXP ioctl %u\n\n", IntLine);
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor linear exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++               pIMX678Ctx->IntLine = IntLine;
++            }
++            TRACE(IMX678_INFO, "%s set linear exp %d \n", __func__,IntLine);
++            pIMX678Ctx->IntTime.IntegrationTime.linearInt =  IntLine * oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            IntLine = pIntegrationTime->IntegrationTime.dualInt.dualIntTime;
++            if (IntLine != pIMX678Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor dual exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX678Ctx->IntLine = IntLine;
++            }
++
++            if (pIMX678Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                ShortIntLine = pIntegrationTime->IntegrationTime.dualInt.dualSIntTime;
++                if (ShortIntLine != pIMX678Ctx->ShortIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX678_ERROR,"%s:set sensor dual vsexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX678Ctx->ShortIntLine = ShortIntLine;
++                }
++            } else {
++                ShortIntLine = IntLine;
++                pIMX678Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX678_INFO, "%s set dual exp %d short_exp %d\n", __func__, IntLine, ShortIntLine);
++            pIMX678Ctx->IntTime.IntegrationTime.dualInt.dualIntTime  = IntLine + oneLineTime;
++            pIMX678Ctx->IntTime.IntegrationTime.dualInt.dualSIntTime = ShortIntLine + oneLineTime;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            if (pIMX678Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triLIntTime;
++                if (LongIntLine != pIMX678Ctx->LongIntLine) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_EXP, &LongIntLine);
++                    if (ret != 0) {
++                        TRACE(IMX678_ERROR,"%s:set sensor tri lexp error!\n", __func__);
++                        return RET_FAILURE;
++                    }
++                    pIMX678Ctx->LongIntLine = LongIntLine;
++                }
++            } else {
++                LongIntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++                pIMX678Ctx->LongIntLine = LongIntLine;
++            }
++
++            IntLine = pIntegrationTime->IntegrationTime.triInt.triIntTime;
++            if (IntLine != pIMX678Ctx->IntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_EXP, &IntLine);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri exp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX678Ctx->IntLine = IntLine;
++            }
++            
++            ShortIntLine = pIntegrationTime->IntegrationTime.triInt.triSIntTime;
++            if (ShortIntLine != pIMX678Ctx->ShortIntLine) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSEXP, &ShortIntLine);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri vsexp error!\n", __func__);
++                    return RET_FAILURE;
++                }
++                pIMX678Ctx->ShortIntLine = ShortIntLine;
++            }
++            TRACE(IMX678_INFO, "%s set tri long exp %d exp %d short_exp %d\n", __func__, LongIntLine, IntLine, ShortIntLine);
++            pIMX678Ctx->IntTime.IntegrationTime.triInt.triLIntTime = LongIntLine + oneLineTime;
++            pIMX678Ctx->IntTime.IntegrationTime.triInt.triIntTime = IntLine + oneLineTime;
++            pIMX678Ctx->IntTime.IntegrationTime.triInt.triSIntTime = ShortIntLine + oneLineTime;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++    
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++    memcpy(pGain, &pIMX678Ctx->SensorGain, sizeof(IsiSensorGain_t));
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetGainIss(IsiSensorHandle_t handle, IsiSensorGain_t *pGain)
++{
++    int ret = 0;
++    uint32_t LongGain;
++    uint32_t Gain;
++    uint32_t ShortGain;
++
++    TRACE(IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pGain == NULL)
++        return RET_NULL_POINTER;
++
++    pIMX678Ctx->SensorGain.expoFrmType = pGain->expoFrmType;
++    switch (pGain->expoFrmType) {
++        case ISI_EXPO_FRAME_TYPE_1FRAME:
++            Gain = pGain->gain.linearGainParas;
++            if (pIMX678Ctx->SensorGain.gain.linearGainParas != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor linear gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            pIMX678Ctx->SensorGain.gain.linearGainParas = pGain->gain.linearGainParas;
++            TRACE(IMX678_INFO, "%s set linear gain %d\n", __func__,pGain->gain.linearGainParas);
++            break;
++        case ISI_EXPO_FRAME_TYPE_2FRAMES:
++            Gain = pGain->gain.dualGainParas.dualGain;
++            if (pIMX678Ctx->SensorGain.gain.dualGainParas.dualGain != Gain) {
++                if (pIMX678Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &Gain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor dual gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.dualGainParas.dualSGain;
++            if (pIMX678Ctx->SensorGain.gain.dualGainParas.dualSGain != ShortGain) {
++                if (pIMX678Ctx->CurMode.stitching_mode != SENSOR_STITCHING_DUAL_DCG_NOWAIT) {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                } else {
++                    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &ShortGain);
++                }
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor dual vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX678_INFO,"%s:set gain%d short gain %d!\n", __func__,Gain,ShortGain);
++            pIMX678Ctx->SensorGain.gain.dualGainParas.dualGain = Gain;
++            pIMX678Ctx->SensorGain.gain.dualGainParas.dualSGain = ShortGain;
++            break;
++        case ISI_EXPO_FRAME_TYPE_3FRAMES:
++            LongGain = pGain->gain.triGainParas.triLGain;
++            if (pIMX678Ctx->SensorGain.gain.triGainParas.triLGain != LongGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_LONG_GAIN, &LongGain);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            Gain = pGain->gain.triGainParas.triGain;
++            if (pIMX678Ctx->SensorGain.gain.triGainParas.triGain != Gain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_GAIN, &Gain);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++
++            ShortGain = pGain->gain.triGainParas.triSGain;
++            if (pIMX678Ctx->SensorGain.gain.triGainParas.triSGain != ShortGain) {
++                ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_VSGAIN, &ShortGain);
++                if (ret != 0) {
++                    TRACE(IMX678_ERROR,"%s:set sensor tri vs gain error!\n", __func__);
++                    return RET_FAILURE;
++                }
++            }
++            TRACE(IMX678_INFO,"%s:set long gain %d gain%d short gain %d!\n", __func__, LongGain, Gain, ShortGain);
++            pIMX678Ctx->SensorGain.gain.triGainParas.triLGain = LongGain;
++            pIMX678Ctx->SensorGain.gain.triGainParas.triGain = Gain;
++            pIMX678Ctx->SensorGain.gain.triGainParas.triSGain = ShortGain;
++            break;
++        default:
++            return RET_FAILURE;
++            break;
++    }
++
++    TRACE(IMX678_INFO, "%s (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++
++static RESULT IMX678_IsiGetSensorFpsIss(IsiSensorHandle_t handle, uint32_t * pfps)
++{
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    if (pfps == NULL)
++        return RET_NULL_POINTER;
++
++    *pfps = pIMX678Ctx->CurMode.ae_info.cur_fps;
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetSensorFpsIss(IsiSensorHandle_t handle, uint32_t fps)
++{
++    int ret = 0;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_FPS, &fps);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR,"%s:set sensor fps error!\n", __func__);
++        return RET_FAILURE;
++    }
++    struct vvcam_mode_info_s SensorMode;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_SENSOR_MODE, &SensorMode);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR,"%s:get sensor mode error!\n", __func__);
++        return RET_FAILURE;
++    }
++    memcpy(&pIMX678Ctx->CurMode, &SensorMode, sizeof(struct vvcam_mode_info_s));
++    IMX678_UpdateIsiAEInfo(handle);
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++static RESULT IMX678_IsiSetSensorAfpsLimitsIss(IsiSensorHandle_t handle, uint32_t minAfps)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    if ((minAfps > pIMX678Ctx->CurMode.ae_info.max_fps) ||
++        (minAfps < pIMX678Ctx->CurMode.ae_info.min_fps))
++        return RET_FAILURE;
++    pIMX678Ctx->minAfps = minAfps;
++    pIMX678Ctx->CurMode.ae_info.min_afps = minAfps;
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetSensorIspStatusIss(IsiSensorHandle_t handle,
++                               IsiSensorIspStatus_t *pSensorIspStatus)
++{
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    if (pIMX678Ctx->CurMode.hdr_mode == SENSOR_MODE_HDR_NATIVE) {
++        pSensorIspStatus->useSensorAWB = true;
++        pSensorIspStatus->useSensorBLC = true;
++    } else {
++        pSensorIspStatus->useSensorAWB = false;
++        pSensorIspStatus->useSensorBLC = false;
++    }
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++#ifndef ISI_LITE
++static RESULT IMX678_IsiSensorSetBlcIss(IsiSensorHandle_t handle, IsiSensorBlc_t * pBlc)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pBlc == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_blc_s SensorBlc;
++    SensorBlc.red = pBlc->red;
++    SensorBlc.gb = pBlc->gb;
++    SensorBlc.gr = pBlc->gr;
++    SensorBlc.blue = pBlc->blue;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_BLC, &SensorBlc);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorSetWBIss(IsiSensorHandle_t handle, IsiSensorWB_t *pWb)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pWb == NULL)
++        return RET_NULL_POINTER;
++
++    struct sensor_white_balance_s SensorWb;
++    SensorWb.r_gain = pWb->r_gain;
++    SensorWb.gr_gain = pWb->gr_gain;
++    SensorWb.gb_gain = pWb->gb_gain;
++    SensorWb.b_gain = pWb->b_gain;
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_WB, &SensorWb);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: set wb error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSensorGetExpandCurveIss(IsiSensorHandle_t handle, IsiSensorExpandCurve_t *pExpandCurve)
++{
++    int32_t ret = 0;
++
++    TRACE(IMX678_INFO, "%s: (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    if (pExpandCurve == NULL)
++        return RET_NULL_POINTER;
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_G_EXPAND_CURVE, pExpandCurve);
++    if (ret != 0) {
++        TRACE(IMX678_ERROR, "%s: get  expand cure error\n", __func__);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetTestPatternIss(IsiSensorHandle_t handle,
++                                       IsiSensorTpgMode_e  tpgMode)
++{
++    int32_t ret = 0;
++
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++    HalContext_t *pHalCtx = (HalContext_t *) pIMX678Ctx->IsiCtx.HalHandle;
++
++    struct sensor_test_pattern_s TestPattern;
++    if (tpgMode == ISI_TPG_DISABLE) {
++        TestPattern.enable = 0;
++        TestPattern.pattern = 0;
++    } else {
++        TestPattern.enable = 1;
++        TestPattern.pattern = (uint32_t)tpgMode - 1;
++    }
++
++    ret = ioctl(pHalCtx->sensor_fd, VVSENSORIOC_S_TEST_PATTERN, &TestPattern);
++    if (ret != 0)
++    {
++        TRACE(IMX678_ERROR, "%s: set test pattern %d error\n", __func__, tpgMode);
++        return RET_FAILURE;
++    }
++
++    TRACE(IMX678_INFO, "%s: test pattern enable[%d] mode[%d]\n", __func__, TestPattern.enable, TestPattern.pattern);
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiFocusSetupIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiFocusReleaseIss(IsiSensorHandle_t handle)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiFocusGetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiFocusSetIss(IsiSensorHandle_t handle, IsiFocusPos_t *pPos)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetFocusCalibrateIss(IsiSensorHandle_t handle, IsiFoucsCalibAttr_t *pFocusCalib)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiGetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t *pExposure)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    if (pIMX678Ctx->AEStartExposure == 0) {
++        pIMX678Ctx->AEStartExposure =
++            (uint64_t)pIMX678Ctx->CurMode.ae_info.start_exposure *
++            pIMX678Ctx->CurMode.ae_info.one_line_exp_time_ns / 1000;
++           
++    }
++    *pExposure =  pIMX678Ctx->AEStartExposure;
++    TRACE(IMX678_INFO, "%s:get start exposure %d\n", __func__, pIMX678Ctx->AEStartExposure);
++
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++static RESULT IMX678_IsiSetAeStartExposureIs(IsiSensorHandle_t handle, uint64_t exposure)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++    IMX678_Context_t *pIMX678Ctx = (IMX678_Context_t *) handle;
++
++    pIMX678Ctx->AEStartExposure = exposure;
++    TRACE(IMX678_INFO, "set start exposure %d\n", __func__,pIMX678Ctx->AEStartExposure);
++    TRACE(IMX678_INFO, "%s: (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++#endif
++
++RESULT IMX678_IsiGetSensorIss(IsiSensor_t *pIsiSensor)
++{
++    TRACE( IMX678_INFO, "%s (enter)\n", __func__);
++
++    if (pIsiSensor == NULL)
++        return RET_NULL_POINTER;
++     pIsiSensor->pszName                         = SensorName;
++     pIsiSensor->pIsiSensorSetPowerIss           = IMX678_IsiSensorSetPowerIss;
++     pIsiSensor->pIsiCreateSensorIss             = IMX678_IsiCreateSensorIss;
++     pIsiSensor->pIsiReleaseSensorIss            = IMX678_IsiReleaseSensorIss;
++     pIsiSensor->pIsiRegisterReadIss             = IMX678_IsiRegisterReadIss;
++     pIsiSensor->pIsiRegisterWriteIss            = IMX678_IsiRegisterWriteIss;
++     pIsiSensor->pIsiGetSensorModeIss            = IMX678_IsiGetSensorModeIss;
++     pIsiSensor->pIsiSetSensorModeIss            = IMX678_IsiSetSensorModeIss;
++     pIsiSensor->pIsiQuerySensorIss              = IMX678_IsiQuerySensorIss;
++     pIsiSensor->pIsiGetCapsIss                  = IMX678_IsiGetCapsIss;
++     pIsiSensor->pIsiSetupSensorIss              = IMX678_IsiSetupSensorIss;
++     pIsiSensor->pIsiGetSensorRevisionIss        = IMX678_IsiGetSensorRevisionIss;
++     pIsiSensor->pIsiCheckSensorConnectionIss    = IMX678_IsiCheckSensorConnectionIss;
++     pIsiSensor->pIsiSensorSetStreamingIss       = IMX678_IsiSensorSetStreamingIss;
++     pIsiSensor->pIsiGetAeInfoIss                = IMX678_IsiGetAeInfoIss;
++     pIsiSensor->pIsiSetHdrRatioIss              = IMX678_IsiSetHdrRatioIss;
++     pIsiSensor->pIsiGetIntegrationTimeIss       = IMX678_IsiGetIntegrationTimeIss;
++     pIsiSensor->pIsiSetIntegrationTimeIss       = IMX678_IsiSetIntegrationTimeIss;
++     pIsiSensor->pIsiGetGainIss                  = IMX678_IsiGetGainIss;
++     pIsiSensor->pIsiSetGainIss                  = IMX678_IsiSetGainIss;
++     pIsiSensor->pIsiGetSensorFpsIss             = IMX678_IsiGetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorFpsIss             = IMX678_IsiSetSensorFpsIss;
++     pIsiSensor->pIsiSetSensorAfpsLimitsIss      = IMX678_IsiSetSensorAfpsLimitsIss;
++     pIsiSensor->pIsiGetSensorIspStatusIss       = IMX678_IsiGetSensorIspStatusIss;
++#ifndef ISI_LITE
++    pIsiSensor->pIsiSensorSetBlcIss              = IMX678_IsiSensorSetBlcIss;
++    pIsiSensor->pIsiSensorSetWBIss               = IMX678_IsiSensorSetWBIss;
++    pIsiSensor->pIsiSensorGetExpandCurveIss      = IMX678_IsiSensorGetExpandCurveIss;
++    pIsiSensor->pIsiActivateTestPatternIss       = IMX678_IsiSetTestPatternIss;
++    pIsiSensor->pIsiFocusSetupIss                = IMX678_IsiFocusSetupIss;
++    pIsiSensor->pIsiFocusReleaseIss              = IMX678_IsiFocusReleaseIss;
++    pIsiSensor->pIsiFocusSetIss                  = IMX678_IsiFocusSetIss;
++    pIsiSensor->pIsiFocusGetIss                  = IMX678_IsiFocusGetIss;
++    pIsiSensor->pIsiGetFocusCalibrateIss         = IMX678_IsiGetFocusCalibrateIss;
++    pIsiSensor->pIsiSetAeStartExposureIss        = IMX678_IsiSetAeStartExposureIs;
++    pIsiSensor->pIsiGetAeStartExposureIss        = IMX678_IsiGetAeStartExposureIs;
++#endif
++    TRACE( IMX678_INFO, "%s (exit)\n", __func__);
++    return RET_SUCCESS;
++}
++
++/*****************************************************************************
++* each sensor driver need declare this struct for isi load
++*****************************************************************************/
++IsiCamDrvConfig_t IsiCamDrvConfig = {
++    .CameraDriverID = 0x0678,
++    .pIsiHalQuerySensor = IMX678_IsiHalQuerySensorIss,
++    .pfIsiGetSensorIss = IMX678_IsiGetSensorIss,
++};

--- a/isp/imx8mp/framos/Torizon7/isp-imx/patches/patch.sh
+++ b/isp/imx8mp/framos/Torizon7/isp-imx/patches/patch.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Apply patches
+patch -d /downloads/isp-imx-${ISP_IMX_VERSION}/ -p1 < 0001-isp-imx-start_isp-don-t-report-error-if-no-camera-is.patch 
+patch -d /downloads/isp-imx-${ISP_IMX_VERSION}/ -p1 < 0002-Add-support-for-imx6xx-sensors.patch 

--- a/isp/imx8mp/framos/Torizon7/isp-imx/patches/sed-bash.sh
+++ b/isp/imx8mp/framos/Torizon7/isp-imx/patches/sed-bash.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sed -i 's|^#!/bin/sh|#!/bin/bash|' /downloads/isp-imx-${ISP_IMX_VERSION}/build_output_release_v4l2/opt/imx8-isp/bin/start_isp.sh
+sed -i 's|^#!/bin/sh|#!/bin/bash|' /downloads/isp-imx-${ISP_IMX_VERSION}/build_output_release_v4l2/opt/imx8-isp/bin/run.sh

--- a/isp/imx8mp/framos/download.sh
+++ b/isp/imx8mp/framos/download.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+OPTION=$1
+TORIZON_VERSION=$2
+DRIVER_NAME=$3
+
+
+check_version() {
+
+    if [[ $TORIZON_VERSION == 6 ]]; then
+        TDX_BRANCH="toradex_5.15-2.2.x-imx"
+        META_TDX_FRAMOS_BRANCH="kirkstone-6.x.y"
+    elif [[ $TORIZON_VERSION == 7 ]]; then
+        TDX_BRANCH="toradex_6.6-2.1.x-imx"
+        META_TDX_FRAMOS_BRANCH="scarthgap-7.x.y"
+    else
+        echo "Error: Invalid TorizonOS version!"
+        exit 1
+    fi
+}
+
+download_linux_dt() {
+    
+    check_version
+    echo "download_linux_dt"
+   
+    rm -rf linux
+    rm -rf device-trees
+
+    git clone --depth 3 -b $TDX_BRANCH $T git://git.toradex.com/linux-toradex.git linux
+    git clone --depth 3 -b $TDX_BRANCH git://git.toradex.com/device-tree-overlays.git device-trees
+}
+
+download_driver() {
+    echo "download_driver"
+    check_version
+    if [[ $DRIVER_NAME == "imx662" || $DRIVER_NAME == "imx676" || $DRIVER_NAME == "imx678" ]]; then
+        rm -rf $DRIVER_NAME-driver
+        rm -f "device-trees/overlays/verdin-imx8mp_${DRIVER_NAME}_overlay.dts" 
+
+        wget -P "${DRIVER_NAME}-driver" "https://raw.githubusercontent.com/framosimaging/framos-nxp-drivers/3bb0c957a4e14143451b119d030e39f783767b31/isp-vvcam/vvcam/v4l2/sensor/${DRIVER_NAME}/${DRIVER_NAME}_mipi.c"
+        wget -P "${DRIVER_NAME}-driver" "https://raw.githubusercontent.com/framosimaging/framos-nxp-drivers/3bb0c957a4e14143451b119d030e39f783767b31/isp-vvcam/vvcam/v4l2/sensor/${DRIVER_NAME}/${DRIVER_NAME}_regs.h"
+        wget -P "${DRIVER_NAME}-driver" "https://raw.githubusercontent.com/framosimaging/framos-nxp-drivers/3bb0c957a4e14143451b119d030e39f783767b31/isp-vvcam/vvcam/common/vvsensor.h"
+        wget -P "${DRIVER_NAME}-driver" "https://raw.githubusercontent.com/toradex/meta-toradex-framos/${META_TDX_FRAMOS_BRANCH}/recipes-kernel/${DRIVER_NAME}/files/Makefile"
+        wget -P "device-trees/overlays" "https://raw.githubusercontent.com/toradex/meta-toradex-framos/${META_TDX_FRAMOS_BRANCH}/recipes-kernel/linux/device-tree-overlays/verdin-imx8mp_${DRIVER_NAME}_overlay.dts"
+
+    else
+        echo "no sensor specified! Possible options:"
+        echo "imx662"
+        echo "imx676"
+        echo "imx678"
+        
+        exit 1
+    fi
+}
+
+clean_all() {
+    echo "clean_all"
+
+    rm -rf linux
+    rm -rf device-trees
+    rm -rf imx*-driver
+}
+
+usage() {
+    echo "Usage:"
+    
+    echo " Download Linux and device-tree-overlays repository: "
+    echo " linux [TORIZON OS VERSION]"
+    echo " examples: ./download linux 6 (For TorizonOS 6)"
+    echo "           ./download linux 7 (For TorizonOS 7)"
+    echo ""
+
+    echo " driver [TORIZON OS VERSION] [DRIVER NAME]: download driver source code"
+    echo " examples: ./download.sh driver 6 imx662 (Driver for IMX662, TorizonOS 6)"
+    echo "           ./download.sh driver 7 imx678 (Driver for IMX678, TorizonOS 7)"
+    echo ""
+    echo " clean: delete all downloaded folders"
+}
+
+case "$1" in
+    linux)
+        download_linux_dt
+        ;;
+    driver)
+        download_driver
+        ;;
+    clean)
+        clean_all
+        ;;
+    *)
+        usage
+        exit 1
+esac


### PR DESCRIPTION
  - Support for Torizon6 (starting from 6.8.0) and Torizon7