### PR TITLE
Update iMX8MPlus supported models for isp framos sample

### DIFF
--- a/isp/imx8mp/framos/README.md
+++ b/isp/imx8mp/framos/README.md
@@ -8,6 +8,7 @@ This sample is compatible with the following hardware:
  - 0070 - Verdin iMX8M Plus Quad 8GB WB IT
  - 0058 - Verdin iMX8M Plus Quad 4GB WB IT
  - 0063 - Verdin iMX8M Plus Quad 4GB IT
+ - 0064 - Verdin iMX8M Plus Quad 2GB WB IT 
 
 Currently, this demo should be used with the following TorizonOS versions:
 


### PR DESCRIPTION
Since the 1GB version of the iMX8MPlus does not have an ISP, it will not support any of the Framos FSM:GO Cameras. Hence, we are updating the documentation to list which versions of this module are supported.