### PR TITLE
Add support for binning (mode 2) of imx676 driver

### DIFF
--- a/isp/imx8mp/framos/Torizon7/isp-imx/patches/0003-add-support-for-imx676-mode-2-binning.patch
+++ b/isp/imx8mp/framos/Torizon7/isp-imx/patches/0003-add-support-for-imx676-mode-2-binning.patch
@@ -1,0 +1,20 @@
+--- a/imx/run.sh	2025-07-22 12:20:48.440591247 -0400
++++ b/imx/run.sh	2025-07-22 12:21:06.080615291 -0400
+@@ -377,7 +377,16 @@
+ 			MODE="0"
+ 			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
+ 			;;
+-
++		imx676_binned )
++			MODULES_TO_REMOVE=(  "imx676" "${MODULES[@]}")
++			MODULES=("imx676" "${MODULES[@]}")
++			RUN_OPTION="CAMERA0"
++			CAM_NAME="imx676"
++			DRV_FILE="imx676.drv"
++			MODE_FILE="IMX676_MODES.txt"
++			MODE="2"
++			write_sensor_cfg_file "Sensor0_Entry.cfg" $CAM_NAME $DRV_FILE $MODE_FILE $MODE
++			;;
+ 		dual_imx676_4k )
+ 			MODULES_TO_REMOVE=("imx676" "${MODULES[@]}")
+ 			MODULES=("imx676" "${MODULES[@]}")

--- a/isp/imx8mp/framos/Torizon7/isp-imx/patches/patch.sh
+++ b/isp/imx8mp/framos/Torizon7/isp-imx/patches/patch.sh
@@ -3,3 +3,4 @@
 # Apply patches
 patch -d /downloads/isp-imx-${ISP_IMX_VERSION}/ -p1 < 0001-isp-imx-start_isp-don-t-report-error-if-no-camera-is.patch 
 patch -d /downloads/isp-imx-${ISP_IMX_VERSION}/ -p1 < 0002-Add-support-for-imx6xx-sensors.patch 
+patch -d /downloads/isp-imx-${ISP_IMX_VERSION}/ -p1 < 0003-add-support-for-imx676-mode-2-binning.patch


### PR DESCRIPTION
Initial forum post: https://community.toradex.com/t/the-toradex-imx676-crops-active-sensor-area/27975/2

The default 4K mode of the IMX676 driver crops the top and bottom of the sensor, due to a resolution limitation of the IMX8M ISP. [This limitation is documented in the FRAMOS driver release notes here](https://github.com/framosimaging/framos-nxp-drivers/wiki/Release-Notes-lf%E2%80%906.6.3_1.0.0#implemented-resolutions-frame-rate-number-of-mipi-csi-lanes-and-bpp).

Our application requires use of the entire square sensor area, so we want to make use of the binning mode (mode 2 of the driver). This give us the entire image captured by the sensor at a 3MP resolution (which is fine for our case).

This PR adds a new patch to the isp-imx example, which adds an `imx676_binned` mode to the list of available options.

This mode can be used in `docker-compose.yaml` file like so:

```docker-compose.yaml
  isp-imx:
    image: [your_dockerhub_user]/torizon7-isp-imx
    container_name: isp-imx
    working_dir: /build-isp-imx/opt/imx8-isp/bin/
    command: ["./run.sh", "-c", "imx676_binned", "-lm"]
#   etc...
```